### PR TITLE
Repro compiler watch issue

### DIFF
--- a/apps/3000-home/components/SharedNav.tsx
+++ b/apps/3000-home/components/SharedNav.tsx
@@ -26,7 +26,7 @@ const SharedNav = () => {
 
   return (
     <Layout.Header>
-      <div className={tjhin}>nextjs-mf</div>
+      <div className="header-logo">nextjs-mf 1234</div>
       <Menu
         theme="dark"
         mode="horizontal"

--- a/packages/nextjs-mf/src/plugins/ChildFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/ChildFederationPlugin.ts
@@ -259,33 +259,7 @@ export class ChildFederationPlugin {
       }
 
       if (isDev) {
-        const compilerWithCallback = (watchOptions: WatchOptions, callback: any) => {
-          if (childCompiler.watch) {
-            if (isServer && !this.watching) {
-              this.watching = true;
-              childCompiler.watch(watchOptions, callback);
-            }
-          } else {
-            childCompiler.run(callback);
-          }
-        }
-
         const compilerCallback = (err: Error | null | undefined, stats: Stats | undefined) => {
-          //workaround due to watch mode not running unless youve hit a page on the remote itself
-          if (isServer && isDev && childCompilers['client']) {
-            childCompilers['client'].run((err, stats) => {
-              if (err) {
-                compilation.errors.push(err as WebpackError);
-              }
-              if (stats && stats.hasErrors()) {
-                compilation.errors.push(
-                  new Error(
-                    toDisplayErrors(stats.compilation.errors)
-                  ) as WebpackError
-                );
-              }
-            });
-          }
           if (err) {
             compilation.errors.push(err as WebpackError);
           }
@@ -298,7 +272,7 @@ export class ChildFederationPlugin {
           }
         }
 
-        compilerWithCallback(compiler.options.watchOptions, compilerCallback);
+        childCompiler.watch(compiler.options.watchOptions, compilerCallback);
 
 
         // in prod, if client


### PR DESCRIPTION
run `yarn start`

open` localhost:3001`
make edits to SharedNav i home-3000/components/SharedName

something like
`<div className="header-logo">nextjs-mf 12348273</div>`

refresh localhost:3001 - no files have changed, check terminal of node - errors are thrown.

Watch mode only seems to actually rebuild changes if and only if I go to localhost:3000 FIRST. 
Doing that would not make sense when developing loclly. Sometimes I just need a remote running locally for another host, not wanting to have to always load a page of the remote entry for watch mode to kick in. 

https://github.com/module-federation/nextjs-mf/issues/238