### PR TITLE
fix: #411

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -48,7 +48,7 @@ export class TypescriptCompiler {
 
     const program = ts.createProgram(
       [...normalizedAdditionalFiles, ...normalizedExposedComponents],
-      this.compilerOptions,
+      {...this.compilerOptions, outDir: path.join(this.compilerOptions.outDir, exposeDest)},
       host
     );
 

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -37,7 +37,6 @@ export class TypescriptCompiler {
     };
 
     const normalizedExposedComponents = this.normalizeFiles(Object.keys(exposeSrcToDestMap), value => value);
-    this.compilerOptions.outDir = path.join(this.compilerOptions.outDir, exposeDest)
 
     const normalizedAdditionalFiles = this.normalizeFiles(
       additionalFilesToCompile,

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -28,19 +28,16 @@ export class TypescriptCompiler {
   }
 
   generateDeclarationFiles(
-    exposedComponents: ModuleFederationPluginOptions['exposes'],
+    exposeDest: string,
+    exposeSrc: string,
     additionalFilesToCompile: FederatedTypesPluginOptions['additionalFilesToCompile'] = []
   ) {
-    const exposeSrcToDestMap: Record<string, string> = {};
+    const exposeSrcToDestMap: Record<string, string> = {
+      [this.getNormalizedPathWithExt(exposeSrc)]: exposeDest,
+    };
 
-    const normalizedExposedComponents = this.normalizeFiles(
-      Object.entries(exposedComponents!),
-      ([exposeDest, exposeSrc]) => {
-        const pathWithExt = this.getNormalizedPathWithExt(exposeSrc);
-        exposeSrcToDestMap[pathWithExt] = exposeDest;
-        return pathWithExt;
-      }
-    );
+    const normalizedExposedComponents = this.normalizeFiles(Object.keys(exposeSrcToDestMap), value => value);
+    this.compilerOptions.outDir = path.join(this.compilerOptions.outDir, exposeDest)
 
     const normalizedAdditionalFiles = this.normalizeFiles(
       additionalFilesToCompile,
@@ -100,7 +97,7 @@ export class TypescriptCompiler {
 
       return (
         destFile &&
-        path.join(this.compilerOptions.outDir as string, `${destFile}.d.ts`)
+        path.join(this.compilerOptions.outDir as string, 'index.d.ts')
       );
     };
 

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -81,8 +81,7 @@ export class TypescriptCompiler {
       entry
     );
 
-    const pathWithExt = path.resolve(normalizedRootDir, filenameWithExt);
-    return pathWithExt;
+    return path.resolve(normalizedRootDir, filenameWithExt);
   }
 
   private createHost(exposeSrcToDestMap: Record<string, string>) {

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -119,11 +119,10 @@ export class FederatedTypesPlugin {
     const compiler = new TypescriptCompiler(this.normalizeOptions);
 
     try {
-      const filesMap = compiler.generateDeclarationFiles(
-        exposedComponents,
-        this.options.additionalFilesToCompile
-      );
-      return filesMap;
+      return Object.entries(exposedComponents).reduce((accumulator, [exposeDest, exposeSrc]) => {
+        accumulator = {...accumulator, ...compiler.generateDeclarationFiles(exposeDest, exposeSrc, this.options.additionalFilesToCompile)}
+        return accumulator
+      }, {})
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -119,9 +119,10 @@ export class FederatedTypesPlugin {
     const compiler = new TypescriptCompiler(this.normalizeOptions);
 
     try {
-      return Object.entries(exposedComponents).reduce((accumulator, [exposeDest, exposeSrc]) => {
-        return {...accumulator, ...compiler.generateDeclarationFiles(exposeDest, exposeSrc, this.options.additionalFilesToCompile)}
-      }, {})
+      return Object.entries(exposedComponents).reduce((accumulator, [exposeDest, exposeSrc]) => ({
+        ...accumulator, 
+        ...compiler.generateDeclarationFiles(exposeDest, exposeSrc, this.options.additionalFilesToCompile)
+      }), {})
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -120,8 +120,7 @@ export class FederatedTypesPlugin {
 
     try {
       return Object.entries(exposedComponents).reduce((accumulator, [exposeDest, exposeSrc]) => {
-        accumulator = {...accumulator, ...compiler.generateDeclarationFiles(exposeDest, exposeSrc, this.options.additionalFilesToCompile)}
-        return accumulator
+        return {...accumulator, ...compiler.generateDeclarationFiles(exposeDest, exposeSrc, this.options.additionalFilesToCompile)}
       }, {})
     } catch (error) {
       this.logger.error(error);


### PR DESCRIPTION
Hi everyone 👋

This PR aims to fix #411.

The solution is simple: instead of compiling all the exposed components together, I compile them one at time writing the output in a dedicated folder.

To avoid collision with the component name, the entry definition of the federated module will be 'index.d.ts'.