### PR TITLE
Typescript - use filename path for types

### DIFF
--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -22,8 +22,14 @@ export const normalizeOptions = (
     get(webpackCompilerOptions, 'devServer.static.directory') ||
     get(webpackCompilerOptions, 'output.path') ||
     'dist';
+  const federationFileName = options.federationConfig.filename as string;
 
-  const distDir = path.join(distPath, typescriptFolderName);
+  const typesPath = federationFileName.substring(
+    0,
+    federationFileName.lastIndexOf('/')
+  );
+
+  const distDir = path.join(distPath, typesPath, typescriptFolderName);
 
   const tsCompilerOptions: ts.CompilerOptions = {
     declaration: true,
@@ -46,6 +52,7 @@ export const normalizeOptions = (
     publicPath,
     tsCompilerOptions,
     typesIndexJsonFileName: TYPES_INDEX_JSON_FILE_NAME,
+    typesIndexJsonFilePath: typesPath,
     typescriptFolderName,
     webpackCompilerOptions,
   };

--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -29,6 +29,11 @@ export const normalizeOptions = (
     federationFileName.lastIndexOf('/')
   );
 
+  const typesIndexJsonFilePath = path.join(
+    typesPath,
+    TYPES_INDEX_JSON_FILE_NAME
+  );
+
   const distDir = path.join(distPath, typesPath, typescriptFolderName);
 
   const tsCompilerOptions: ts.CompilerOptions = {
@@ -52,7 +57,7 @@ export const normalizeOptions = (
     publicPath,
     tsCompilerOptions,
     typesIndexJsonFileName: TYPES_INDEX_JSON_FILE_NAME,
-    typesIndexJsonFilePath: typesPath,
+    typesIndexJsonFilePath,
     typescriptFolderName,
     webpackCompilerOptions,
   };

--- a/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
@@ -3,6 +3,7 @@ import { generateTypesStats } from '../lib/generateTypesStats';
 
 import { NormalizeOptions } from '../lib/normalizeOptions';
 import { CompilationParams, TypesStatsJson } from '../types';
+import path from 'path';
 
 const PLUGIN_NAME = 'FederatedTypesStatsPlugin';
 
@@ -21,6 +22,11 @@ export class FederatedTypesStatsPlugin {
         async () => {
           const { typesIndexJsonFileName, publicPath } = this.options;
 
+          const typesIndexJsonFilePath = path.join(
+            this.options.typesIndexJsonFilePath,
+            typesIndexJsonFileName
+          );
+
           const statsJson: TypesStatsJson = {
             publicPath,
             files: generateTypesStats(federatedTypesMap, this.options),
@@ -28,12 +34,12 @@ export class FederatedTypesStatsPlugin {
 
           const source = new sources.RawSource(JSON.stringify(statsJson));
 
-          const asset = compilation.getAsset(typesIndexJsonFileName);
+          const asset = compilation.getAsset(typesIndexJsonFilePath);
 
           if (asset) {
-            compilation.updateAsset(typesIndexJsonFileName, source);
+            compilation.updateAsset(typesIndexJsonFilePath, source);
           } else {
-            compilation.emitAsset(typesIndexJsonFileName, source);
+            compilation.emitAsset(typesIndexJsonFilePath, source);
           }
         }
       );

--- a/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
@@ -20,12 +20,7 @@ export class FederatedTypesStatsPlugin {
           stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
         async () => {
-          const { typesIndexJsonFileName, publicPath } = this.options;
-
-          const typesIndexJsonFilePath = path.join(
-            this.options.typesIndexJsonFilePath,
-            typesIndexJsonFileName
-          );
+          const { typesIndexJsonFilePath, publicPath } = this.options;
 
           const statsJson: TypesStatsJson = {
             publicPath,


### PR DESCRIPTION
Typescript artifacts - @mf-types folder and type stats json should be generated based on the relative path provided in the federatedConfig fileName property. This change moves both artifacts to the filename's relative path on the generation (remote) side:

Examples:
- static/chunks/remoteEntry.js -> static/chunks/@mf-types/*, static/chunks/__type_stats.json
- remoteEntry.js -> @mf-types/*, __type_stats.json (no base path - react test)
- test/remoteEntry.js -> test/@mf-types/*, test/__type_stats.json

There is a regression from [this change](https://github.com/module-federation/universe/pull/413), and this fix additionally moves the @mf-types into the same directory. With [the PR above](https://github.com/module-federation/universe/pull/413), types are fetched from the origin in the host federated config - just the js file is dropped the rest of the url is kept.

@pavandv - would you be able to confirm this fix? Tested against - https://github.com/module-federation/universe/issues/435 with success