### PR TITLE
typescript: fix @mf-types output when exposed component has imports

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -74,6 +74,7 @@ To have the type definitions automatically found for imports, add `paths` in `ts
 | disableTypeCompilation        | boolean  | No       | false       | Disable compiling types for exposed components                                                                                                                                             |
 | disableDownloadingRemoteTypes | boolean  | No       | false       | Disable downloading types from remote apps                                                                                                                                                 |
 | typescriptFolderName          | string   | No       | `@mf-types` | The folder name to download remote types and output compiled types                                                                                                                         |
+| typescriptCompiledFolderName          | string   | No       | `_types` | The folder name to output the raw output from the ts compiler                                                                                                                         |
 | additionalFilesToCompile      | string[] | No       | []          | Any additional files to be included (besides `ModuleFederationPluginOptions.remotes`) in the emission of Typescript types. This is useful for `global.d.ts` files not directly referenced. |
 
 ## Usage in Next.js

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -59,12 +59,15 @@ To have the type definitions automatically found for imports, add `paths` in `ts
 ```json
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "paths": {
       "*": ["./@mf-types/*"]
     }
   }
 }
 ```
+
+`baseUrl` must also be set for `paths` to work properly
 
 ## Plugin Options
 

--- a/packages/typescript/src/constants.ts
+++ b/packages/typescript/src/constants.ts
@@ -1,3 +1,5 @@
 export const TYPESCRIPT_FOLDER_NAME = '@mf-types';
 
+export const TYPESCRIPT_COMPILED_FOLDER_NAME = '_types';
+
 export const TYPES_INDEX_JSON_FILE_NAME = '__types_index.json';

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -117,7 +117,7 @@ export class TypescriptCompiler {
 
       // create reexport file only if the file was marked for exposing
       if (exposedDestFilePath) {
-        const normalizedExposedDestFilePath = path.join(
+        const normalizedExposedDestFilePath = path.resolve(
           this.options.distDir,
           `${exposedDestFilePath}.d.ts`
         );

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -122,16 +122,14 @@ export class TypescriptCompiler {
           `${exposedDestFilePath}.d.ts`
         );
 
-        const relativePathToCompiledFile =
-          './' +
-          path
-            .relative(
-              path.join(normalizedExposedDestFilePath, '../'), // import relative to the folder which contains this file
-              filepath
-            )
-            .replace(/\.d\.ts$/, '');
-
-        const reexport = `export * from '${relativePathToCompiledFile}';\nexport { default } from '${relativePathToCompiledFile}';`;
+        const relativePathToCompiledFile = path.relative(
+          path.dirname(normalizedExposedDestFilePath),
+          filepath
+        );
+        // add ./ so it's always relative, remove d.ts because it's not needed and can throw warnings
+        const importPath =
+          './' + relativePathToCompiledFile.replace(/\.d\.ts$/, '');
+        const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
         // reuse originalWriteFile as it creates folders if they don't exist
         originalWriteFile(
           normalizedExposedDestFilePath,

--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -4,6 +4,7 @@ import get from 'lodash.get';
 import path from 'path';
 
 import {
+  TYPESCRIPT_COMPILED_FOLDER_NAME,
   TYPESCRIPT_FOLDER_NAME,
   TYPES_INDEX_JSON_FILE_NAME,
 } from '../constants';
@@ -15,7 +16,10 @@ export const normalizeOptions = (
   options: FederatedTypesPluginOptions,
   compiler: Compiler
 ) => {
-  const { typescriptFolderName = TYPESCRIPT_FOLDER_NAME } = options;
+  const {
+    typescriptFolderName = TYPESCRIPT_FOLDER_NAME,
+    typescriptCompiledFolderName = TYPESCRIPT_COMPILED_FOLDER_NAME,
+  } = options;
   const webpackCompilerOptions = compiler.options;
 
   const distPath =
@@ -39,7 +43,7 @@ export const normalizeOptions = (
   const tsCompilerOptions: ts.CompilerOptions = {
     declaration: true,
     emitDeclarationOnly: true,
-    outDir: path.join(distDir, '/_compiled/'),
+    outDir: path.join(distDir, `/${typescriptCompiledFolderName}/`),
     noEmit: false,
   };
 

--- a/packages/typescript/src/lib/normalizeOptions.ts
+++ b/packages/typescript/src/lib/normalizeOptions.ts
@@ -39,7 +39,7 @@ export const normalizeOptions = (
   const tsCompilerOptions: ts.CompilerOptions = {
     declaration: true,
     emitDeclarationOnly: true,
-    outDir: path.join(distDir, '/'),
+    outDir: path.join(distDir, '/_compiled/'),
     noEmit: false,
   };
 

--- a/packages/typescript/src/types/index.ts
+++ b/packages/typescript/src/types/index.ts
@@ -7,7 +7,10 @@ export interface FederatedTypesPluginOptions {
   disableTypeCompilation?: boolean;
   disableDownloadingRemoteTypes?: boolean;
   federationConfig: ModuleFederationPluginOptions;
+  /** @default '@mf-types'*/
   typescriptFolderName?: string;
+  /** @default '_types' */
+  typescriptCompiledFolderName?: string;
   additionalFilesToCompile?: string[];
 }
 


### PR DESCRIPTION
Addresses https://github.com/module-federation/universe/issues/411#issuecomment-1364024929

Inspired by the output that [dts-loader](https://github.com/ruanyl/dts-loader) has, it should eliminate most, if not all, issues related to the types output as this pr no longer tampers with the default typescript output behaviour. 

Default compilation compiles into `@mf-types/_types`. Then separately, anything defined in `exposes` will have a file created in `@mf-types`, which allow imports that match the desired expose paths.

<img width="779" alt="image" src="https://user-images.githubusercontent.com/58468238/209463550-842b5cd4-2037-44b8-b1a6-c123d3d63cf2.png">


```js
      exposes: {
        "./fetch-keys": "./lib/swr-fetch-keys",
        "./footer": "./components/Footer",
      },
```

In the screenshot above, you can see that entry points exist for the keys in `exposes` e.g. `./footer`, and this file re-exports `@mf-types/_types/components/Footer` as specified by the value in `exposes`

`additionalFilesToCompile` continues to work and can be imported in another app by doing `remote/_types/path/to/additional/file`
