### PR TITLE
fix(nextjs-mf): fix client-side compilation

### DIFF
--- a/packages/nextjs-mf/src/plugins/ChildFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/ChildFederationPlugin.ts
@@ -262,8 +262,8 @@ export class ChildFederationPlugin {
 
       if (isDev) {
         const compilerWithCallback = (watchOptions: WatchOptions, callback: any) => {
-          if (childCompiler.watch) {
-            if (isServer && !this.watching) {
+          if (childCompiler.watch && isServer) {
+            if (!this.watching) {
               this.watching = true;
               childCompiler.watch(watchOptions, callback);
             }


### PR DESCRIPTION
I noticed in the `nextjs` example in the examples repo, none of the files were being compiled into the `static/chunks` directory.  This appears to be due to the child compiler not running when `isServer=false`.  I've fixed the condition so that `childCompiler.run(...)` will run when `isServer=false`.