### PR TITLE
Add import remote from Utilities repo

### DIFF
--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './utils/common';
 export * from './utils/isEmpty';
+export * from './utils/importRemote';
 export * from './Logger';

--- a/packages/utilities/src/types/global.d.ts
+++ b/packages/utilities/src/types/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    [index: string | number]: any;
+  }
+}

--- a/packages/utilities/src/types/index.ts
+++ b/packages/utilities/src/types/index.ts
@@ -7,13 +7,27 @@ export type ModuleFederationPluginOptions = ConstructorParameters<
   typeof container.ModuleFederationPlugin
 >['0'];
 
-declare const __webpack_share_scopes__: Record<
+export type WebpackRequire = {
+  l: (
+    url: string,
+    cb: (event: any) => void,
+    id: string
+  ) => Record<string, unknown>;
+};
+
+export type WebpackShareScopes = Record<
   string,
   Record<
     string,
     { loaded?: 1; get: () => Promise<unknown>; from: string; eager: boolean }
   >
->;
+> & {
+  default?: string;
+};
+
+export declare const __webpack_init_sharing__: (
+  parameter: string
+) => Promise<void>;
 
 export interface NextFederationPluginExtraOptions {
   enableImageLoaderFix?: boolean;

--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -1,0 +1,95 @@
+import type { WebpackRequire, WebpackShareScopes } from '../types/index';
+
+export interface ImportRemoteOptions {
+  url: string;
+  scope: string;
+  module: string;
+  remoteEntryFileName?: string;
+  bustRemoteEntryCache?: boolean;
+}
+
+const REMOTE_ENTRY_FILE = 'remoteEntry.js';
+
+const webpackRequire = __webpack_require__ as unknown as WebpackRequire;
+const webpackShareScopes =
+  __webpack_share_scopes__ as unknown as WebpackShareScopes;
+
+const loadRemote = (
+  url: ImportRemoteOptions['url'],
+  scope: ImportRemoteOptions['scope'],
+  bustRemoteEntryCache: ImportRemoteOptions['bustRemoteEntryCache']
+) =>
+  new Promise<void>((resolve, reject) => {
+    const timestamp = bustRemoteEntryCache ? `?t=${new Date().getTime()}` : '';
+    webpackRequire.l(
+      `${url}${timestamp}`,
+      (event) => {
+        if (event?.type === 'load') {
+          // Script loaded successfully:
+          return resolve();
+        }
+        const realSrc = event?.target?.src;
+        const error = new Error();
+        error.message = 'Loading script failed.\n(missing: ' + realSrc + ')';
+        error.name = 'ScriptExternalLoadError';
+        reject(error);
+      },
+      scope
+    );
+  });
+
+const initSharing = async () => {
+  if (!webpackShareScopes?.default) {
+    await __webpack_init_sharing__('default');
+  }
+};
+
+// __initialized and __initializing flags prevent some concurrent re-initialization corner cases
+const initContainer = async (containerScope: any) => {
+  try {
+    if (!containerScope.__initialized && !containerScope.__initializing) {
+      containerScope.__initializing = true;
+      await containerScope.init(webpackShareScopes.default);
+      containerScope.__initialized = true;
+      delete containerScope.__initializing;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/*
+    Dynamically import a remote module using Webpack's loading mechanism:
+    https://webpack.js.org/concepts/module-federation/
+  */
+export const importRemote = async <T>({
+  url,
+  scope,
+  module,
+  remoteEntryFileName = REMOTE_ENTRY_FILE,
+  bustRemoteEntryCache = true,
+}: ImportRemoteOptions): Promise<T> => {
+  if (!window[scope]) {
+    // Load the remote and initialize the share scope if it's empty
+    await Promise.all([
+      loadRemote(`${url}/${remoteEntryFileName}`, scope, bustRemoteEntryCache),
+      initSharing(),
+    ]);
+    if (!window[scope]) {
+      throw new Error(
+        `Remote loaded successfully but ${scope} could not be found! Verify that the name is correct in the Webpack configuration!`
+      );
+    }
+    // Initialize the container to get shared modules and get the module factory:
+    const [, moduleFactory] = await Promise.all([
+      initContainer(window[scope]),
+      window[scope].get(module.startsWith('./') ? module : `./${module}`),
+    ]);
+    return moduleFactory();
+  } else {
+    const moduleFactory = await window[scope].get(
+      module.startsWith('./') ? module : `./${module}`
+    );
+    return moduleFactory();
+  }
+};

--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -1,4 +1,4 @@
-import type { WebpackRequire, WebpackShareScopes } from '../types/index';
+import type { WebpackRequire, WebpackShareScopes } from '../types';
 
 export interface ImportRemoteOptions {
   url: string;


### PR DESCRIPTION
This is a quick port [from the Utilities repo](https://github.com/module-federation/utilities/tree/main/runtime/importRemote). 

@ScriptedAlchemy - curious on your thoughts here, this module works great for pure react, the existing FederationBoundary module in utilities is dependent on next/dynamic and won't run in react. It might be worth keeping them separate long term. What do you think of keeping both but maybe updating the name?