### PR TITLE
fix: bad references to webpack globals

### DIFF
--- a/packages/nextjs-mf/src/include-defaults.ts
+++ b/packages/nextjs-mf/src/include-defaults.ts
@@ -6,8 +6,8 @@ require('next/router');
 require('next/head');
 require('next/script');
 require('next/dynamic');
-require('styled-jsx');
-require('styled-jsx/style');
+const styledJsx = ()=>import("styled-jsx");
+const styledStyle = ()=>import('styled-jsx/style');
 
 if (process.env['NODE_ENV'] === 'development') {
   require('react/jsx-dev-runtime');

--- a/packages/nextjs-mf/src/include-defaults.ts
+++ b/packages/nextjs-mf/src/include-defaults.ts
@@ -6,8 +6,8 @@ require('next/router');
 require('next/head');
 require('next/script');
 require('next/dynamic');
-const styledJsx = ()=>import("styled-jsx");
-const styledStyle = ()=>import('styled-jsx/style');
+require('styled-jsx');
+require('styled-jsx/style');
 
 if (process.env['NODE_ENV'] === 'development') {
   require('react/jsx-dev-runtime');

--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -10,10 +10,6 @@ export interface ImportRemoteOptions {
 
 const REMOTE_ENTRY_FILE = 'remoteEntry.js';
 
-const webpackRequire = __webpack_require__ as unknown as WebpackRequire;
-const webpackShareScopes =
-  __webpack_share_scopes__ as unknown as WebpackShareScopes;
-
 const loadRemote = (
   url: ImportRemoteOptions['url'],
   scope: ImportRemoteOptions['scope'],
@@ -21,6 +17,7 @@ const loadRemote = (
 ) =>
   new Promise<void>((resolve, reject) => {
     const timestamp = bustRemoteEntryCache ? `?t=${new Date().getTime()}` : '';
+    const webpackRequire = __webpack_require__ as unknown as WebpackRequire;
     webpackRequire.l(
       `${url}${timestamp}`,
       (event) => {
@@ -39,6 +36,8 @@ const loadRemote = (
   });
 
 const initSharing = async () => {
+  const webpackShareScopes =
+    __webpack_share_scopes__ as unknown as WebpackShareScopes;
   if (!webpackShareScopes?.default) {
     await __webpack_init_sharing__('default');
   }
@@ -47,6 +46,8 @@ const initSharing = async () => {
 // __initialized and __initializing flags prevent some concurrent re-initialization corner cases
 const initContainer = async (containerScope: any) => {
   try {
+    const webpackShareScopes =
+      __webpack_share_scopes__ as unknown as WebpackShareScopes;
     if (!containerScope.__initialized && !containerScope.__initializing) {
       containerScope.__initializing = true;
       await containerScope.init(webpackShareScopes.default);


### PR DESCRIPTION
bad references in utils to webpack globals

lazy import styled jsx and styles in the event its not used