### PR TITLE
ci: git tags should match with release versions

### DIFF
--- a/packages/nextjs-mf/project.json
+++ b/packages/nextjs-mf/project.json
@@ -64,7 +64,7 @@
     "npm": {
       "executor": "ngx-deploy-npm:deploy",
       "options": {
-        "noBuild": true
+        "access": "public"
       }
     }
   },


### PR DESCRIPTION
Fixes #460

I suspect the issue may be caused because the npm release process is depending on a build output that doesn't factor in the package version uprev and the newly built dependent packages.  The current GHA builds the library in the `Build` step before `node` and `utilities` are built in the `Version` step, which I believe is causing the dependency mismatch.