### PR TITLE
fix(utilities): set webpack peer dep to ^5.40.0

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -15,5 +15,8 @@
   "devDependencies": {
     "react": "18.2.0",
     "next": "13.0.0"
+  },
+  "peerDependencies": {
+    "webpack": "^5.40.0"
   }
 }


### PR DESCRIPTION
The current webpack peer dep in the release is pinned to `5.74.0`.  This change will loosen the deps so that anything `^5.40.0` is allowed.  `5.40.0` was chosen to match the peer deps of the other packages.