### PR TITLE
fix(utilities): move tslib from peer deps into deps

### DIFF
--- a/packages/utilities/project.json
+++ b/packages/utilities/project.json
@@ -11,6 +11,8 @@
         "outputPath": "dist/packages/utilities",
         "main": "packages/utilities/src/index.ts",
         "tsConfig": "packages/utilities/tsconfig.lib.json",
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true,
         "assets": ["packages/utilities/*.md"]
       }
     },


### PR DESCRIPTION
Currently, `tslib` is set as a peer dep in `utilities`, but this should be more appropriate as a regular dependency, similar to the other packages.