### PR TITLE
fix(nextjs-mf): fix FlushedChunks TS declaration

### DIFF
--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -1,40 +1,61 @@
-import * as React from "react";
-export { extractUrlAndGlobal, injectScript } from '@module-federation/utilities';
+import * as React from 'react';
+export {
+  extractUrlAndGlobal,
+  injectScript,
+} from '@module-federation/utilities';
 // @ts-ignore
-export {flushChunks} from '@module-federation/node/utils';
+export { flushChunks } from '@module-federation/node/utils';
 
 export const revalidate = () => {
-  if(typeof window !== 'undefined') {
+  if (typeof window !== 'undefined') {
     console.error('revalidate should only be called server-side');
     return Promise.resolve(false);
   }
   // @ts-ignore
   return import('@module-federation/node/utils').then((utils) => {
     return utils.revalidate();
-  })
+  });
+};
+
+export interface FlushedChunksProps {
+  chunks: string[];
 }
 
-//@ts-ignore
-export const FlushedChunks = ({ chunks })=>{
-  //@ts-ignore
-  const scripts = chunks.filter((c)=>c.endsWith(".js")).map((chunk)=> {
-    if(!chunk.includes('?') && chunk.includes('remoteEntry')) {
-      chunk = chunk + '?t=' + Date.now();
-    }
-    return React.createElement("script", {
-      src: chunk,
-      async: true
-    }, null)
+export const FlushedChunks = ({ chunks }: FlushedChunksProps) => {
+  const scripts = chunks
+    .filter((c) => c.endsWith('.js'))
+    .map((chunk) => {
+      if (!chunk.includes('?') && chunk.includes('remoteEntry')) {
+        chunk = chunk + '?t=' + Date.now();
+      }
+      return React.createElement(
+        'script',
+        {
+          src: chunk,
+          async: true,
+        },
+        null
+      );
+    });
+
+  const css = chunks
+    .filter((c) => c.endsWith('.css'))
+    .map((chunk) => {
+      return React.createElement(
+        'link',
+        {
+          href: chunk,
+          rel: 'stylesheet',
+        },
+        null
+      );
+    });
+
+  return React.createElement(React.Fragment, {
+    children: [css, scripts],
   });
-  //@ts-ignore
-  const css = chunks.filter((c)=>c.endsWith(".css")).map((chunk)=> {
-    return React.createElement("link", {
-      href: chunk,
-      rel: "stylesheet"
-    }, null)
-  });
-  return [css,scripts];
 };
+
 FlushedChunks.defaultProps = {
-  chunks: []
-};
+  chunks: [],
+} as FlushedChunksProps;

--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -51,9 +51,7 @@ export const FlushedChunks = ({ chunks }: FlushedChunksProps) => {
       );
     });
 
-  return React.createElement(React.Fragment, {
-    children: [css, scripts],
-  });
+  return React.createElement(React.Fragment, null, css, scripts);
 };
 
 FlushedChunks.defaultProps = {


### PR DESCRIPTION
This fixes FlushedChunks so it can be used in a TS project.  It currently throws this error when trying to use it.

```
'FlushedChunks' cannot be used as a JSX component.
  Its return type 'any[]' is not a valid JSX element.
```

I've changed the code so that it wraps the children within a fragment so that the correct type can be inferred.  I've also fixed the props declaration.