### PR TITLE
fix(typescript): defined exposes declaration files now consumable

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -130,6 +130,9 @@ export class TypescriptCompiler {
         const importPath =
           './' + relativePathToCompiledFile.replace(/\.d\.ts$/, '');
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
+
+        this.tsDefinitionFilesObj[`${this.options.distDir}/${exposedDestFilePath.replace('./', '')}.d.ts`] = reexport;
+        
         // reuse originalWriteFile as it creates folders if they don't exist
         originalWriteFile(
           normalizedExposedDestFilePath,

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -131,7 +131,7 @@ export class TypescriptCompiler {
           './' + relativePathToCompiledFile.replace(/\.d\.ts$/, '');
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
 
-        this.tsDefinitionFilesObj[`${this.options.distDir}/${exposedDestFilePath.replace('./', '')}.d.ts`] = reexport;
+        this.tsDefinitionFilesObj[normalizedExposedDestFilePath] = reexport;
         
         // reuse originalWriteFile as it creates folders if they don't exist
         originalWriteFile(

--- a/packages/typescript/src/lib/generateTypesStats.ts
+++ b/packages/typescript/src/lib/generateTypesStats.ts
@@ -6,8 +6,9 @@ export const generateTypesStats = (
   normalizeOptions: NormalizeOptions
 ) => {
   return Object.entries(filesMap).reduce((acc, [path, contents]) => {
-    const filename = path.slice(`${normalizeOptions.distDir}/`.length);
-
+    const filename = path.slice(
+      path.indexOf(normalizeOptions.distDir) + `${normalizeOptions.distDir}/`.length
+    );
     return {
       ...acc,
       [filename]: crypto.createHash('md5').update(contents).digest('hex'),


### PR DESCRIPTION
Declaration files for defined exposes are now written to the types index JSON file referenced by consumers.

#486 