### PR TITLE
Typescript - fix child compiler already started

### DIFF
--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -115,9 +115,9 @@ export class FederatedTypesPlugin {
         const filesMap = this.compileTypes();
 
         (params as CompilationParams).federated_types = filesMap;
-
-        new FederatedTypesStatsPlugin(this.normalizeOptions).apply(compiler);
       });
+
+      new FederatedTypesStatsPlugin(this.normalizeOptions).apply(compiler);
     }
 
     new webpack.container.ModuleFederationPlugin(
@@ -170,7 +170,7 @@ export class FederatedTypesPlugin {
       }
     );
 
-    remoteUrls.forEach(async ({ origin, remote }) => {
+    for await (const { origin, remote } of remoteUrls) {
       const { typescriptFolderName } = this.normalizeOptions;
 
       this.logger.log(`Getting types index for remote '${remote}'`);
@@ -219,6 +219,6 @@ export class FederatedTypesPlugin {
 
         this.logger.log('downloading complete');
       }
-    });
+    }
   }
 }

--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -30,6 +30,11 @@ export class FederatedTypesPlugin {
 
   constructor(private options: FederatedTypesPluginOptions) {}
 
+  getError(error: unknown): Error {
+    if (error instanceof Error) return error;
+    return new Error(error as string);
+  }
+
   apply(compiler: Compiler) {
     const {
       disableDownloadingRemoteTypes = false,
@@ -67,12 +72,14 @@ export class FederatedTypesPlugin {
     const ignoredWatchOptions = watchOptions.ignored;
 
     const watchOptionsToIgnore = [
-      path.normalize(path.join(
-        context as string,
-        this.normalizeOptions.typescriptFolderName,
-        '**',
-        '*'
-      )),
+      path.normalize(
+        path.join(
+          context as string,
+          this.normalizeOptions.typescriptFolderName,
+          '**',
+          '*'
+        )
+      ),
     ];
 
     compiler.options.watchOptions.ignored = Array.isArray(ignoredWatchOptions)
@@ -82,12 +89,22 @@ export class FederatedTypesPlugin {
     if (!disableDownloadingRemoteTypes) {
       compiler.hooks.beforeRun.tapAsync(PLUGIN_NAME, async (_, callback) => {
         this.logger.log('Preparing to download types from remotes on startup');
-        await this.importRemoteTypes(callback);
+        try {
+          await this.importRemoteTypes();
+          callback();
+        } catch (error) {
+          callback(this.getError(error));
+        }
       });
 
       compiler.hooks.watchRun.tapAsync(PLUGIN_NAME, async (_, callback) => {
         this.logger.log('Preparing to download types from remotes');
-        await this.importRemoteTypes(callback);
+        try {
+          await this.importRemoteTypes();
+          callback();
+        } catch (error) {
+          callback(this.getError(error));
+        }
       });
     }
 
@@ -98,9 +115,9 @@ export class FederatedTypesPlugin {
         const filesMap = this.compileTypes();
 
         (params as CompilationParams).federated_types = filesMap;
-      });
 
-      new FederatedTypesStatsPlugin(this.normalizeOptions).apply(compiler);
+        new FederatedTypesStatsPlugin(this.normalizeOptions).apply(compiler);
+      });
     }
 
     new webpack.container.ModuleFederationPlugin(
@@ -129,7 +146,7 @@ export class FederatedTypesPlugin {
     }
   }
 
-  private async importRemoteTypes(callback: any) {
+  private async importRemoteTypes() {
     const remoteComponents = this.options.federationConfig.remotes;
 
     if (
@@ -137,7 +154,7 @@ export class FederatedTypesPlugin {
       (remoteComponents && isObjectEmpty(remoteComponents))
     ) {
       this.logger.log('No Remote components configured');
-      return callback();
+      return;
     }
 
     this.logger.log('Normalizing remote URLs');
@@ -156,56 +173,51 @@ export class FederatedTypesPlugin {
     remoteUrls.forEach(async ({ origin, remote }) => {
       const { typescriptFolderName } = this.normalizeOptions;
 
-      try {
-        this.logger.log(`Getting types index for remote '${remote}'`);
-        const resp = await axios.get<TypesStatsJson>(
-          `${origin}/${this.normalizeOptions.typesIndexJsonFileName}`
+      this.logger.log(`Getting types index for remote '${remote}'`);
+      const resp = await axios.get<TypesStatsJson>(
+        `${origin}/${this.normalizeOptions.typesIndexJsonFileName}`
+      );
+
+      const statsJson = resp.data;
+
+      this.logger.log(`Checking with Cache entries`);
+      const { filesToCacheBust, filesToDelete } =
+        TypesCache.getCacheBustedFiles(remote, statsJson);
+
+      this.logger.log('filesToCacheBust', filesToCacheBust);
+      this.logger.log('filesToDelete', filesToDelete);
+
+      if (filesToDelete.length > 0) {
+        filesToDelete.forEach((file) => {
+          fs.unlinkSync(
+            path.resolve(
+              this.normalizeOptions.webpackCompilerOptions.context as string,
+              typescriptFolderName,
+              remote,
+              file
+            )
+          );
+        });
+      }
+
+      if (filesToCacheBust.length > 0) {
+        await Promise.all(
+          filesToCacheBust.map((file) => {
+            const url = `${origin}/${typescriptFolderName}/${file}`;
+            const destination = path.join(
+              this.normalizeOptions.webpackCompilerOptions.context as string,
+              typescriptFolderName,
+              remote
+            );
+
+            this.logger.log('Downloading types...');
+            return download(url, destination, {
+              filename: file,
+            });
+          })
         );
 
-        const statsJson = resp.data;
-
-        this.logger.log(`Checking with Cache entries`);
-        const { filesToCacheBust, filesToDelete } =
-          TypesCache.getCacheBustedFiles(remote, statsJson);
-
-        this.logger.log('filesToCacheBust', filesToCacheBust);
-        this.logger.log('filesToDelete', filesToDelete);
-
-        if (filesToDelete.length > 0) {
-          filesToDelete.forEach((file) => {
-            fs.unlinkSync(
-              path.resolve(
-                this.normalizeOptions.webpackCompilerOptions.context as string,
-                typescriptFolderName,
-                remote,
-                file
-              )
-            );
-          });
-        }
-
-        if (filesToCacheBust.length > 0) {
-          await Promise.all(
-            filesToCacheBust.map((file) => {
-              const url = `${origin}/${typescriptFolderName}/${file}`;
-              const destination = path.join(
-                this.normalizeOptions.webpackCompilerOptions.context as string,
-                typescriptFolderName,
-                remote
-              );
-
-              this.logger.log('Downloading types...');
-              return download(url, destination, {
-                filename: file,
-              });
-            })
-          );
-
-          this.logger.log('downloading complete');
-        }
-        callback();
-      } catch (error) {
-        callback(error);
+        this.logger.log('downloading complete');
       }
     });
   }

--- a/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesStatsPlugin.ts
@@ -3,7 +3,6 @@ import { generateTypesStats } from '../lib/generateTypesStats';
 
 import { NormalizeOptions } from '../lib/normalizeOptions';
 import { CompilationParams, TypesStatsJson } from '../types';
-import path from 'path';
 
 const PLUGIN_NAME = 'FederatedTypesStatsPlugin';
 
@@ -14,12 +13,12 @@ export class FederatedTypesStatsPlugin {
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation, params) => {
       const federatedTypesMap = (params as CompilationParams).federated_types;
 
-      compilation.hooks.processAssets.tapPromise(
+      compilation.hooks.processAssets.tap(
         {
           name: PLUGIN_NAME,
           stage: Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
         },
-        async () => {
+        () => {
           const { typesIndexJsonFilePath, publicPath } = this.options;
 
           const statsJson: TypesStatsJson = {


### PR DESCRIPTION
Fix for #455 - in the case of multiple remotes, the compiler callback was being called while it was still running. Made a small refactor to push the callback out of the importRemoteTypes method which also removes the any type. The stats plugin was also using a tapAsync but was not actually using a promise

Verified testing in a separate repo, running nx build typescript and next:start in the repo.