### PR TITLE
fix: resolve fake remote if offline

### DIFF
--- a/packages/nextjs-mf/utils/build-utils.ts
+++ b/packages/nextjs-mf/utils/build-utils.ts
@@ -111,22 +111,6 @@ const IsomorphicRemoteTemplate = function () {
       },
       remote.global
     );
-  }).catch((e)=> {
-    console.error(remote.global, 'is offline, returning fake remote');
-    console.error(e);
-
-    return {
-      fake: true,
-      get: (arg: any) => {
-        console.log('faking', arg, 'module on', remote.global);
-
-        return Promise.resolve(() => {
-          return () => null
-        });
-      },
-      init: () => {
-      }
-    }
   }).then(function () {
     //@ts-ignore
     const globalScope = typeof window !== 'undefined' ? window : global.__remote_scope__;
@@ -173,6 +157,22 @@ const IsomorphicRemoteTemplate = function () {
       proxy.init();
     }
     return proxy;
+  }).catch((e)=> {
+    console.error(remote.global, 'is offline, returning fake remote');
+    console.error(e);
+
+    return {
+      fake: true,
+      get: (arg: any) => {
+        console.log('faking', arg, 'module on', remote.global);
+
+        return Promise.resolve(() => {
+          return () => null
+        });
+      },
+      init: () => {
+      }
+    }
   });
 };
 


### PR DESCRIPTION
Prevent webpack from crashing if remote isnt online, instead return a empty remote interface