### PR TITLE
fix(nextjs-mf): fix list key warning in FlushedChunks

### DIFF
--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -31,6 +31,7 @@ export const FlushedChunks = ({ chunks }: FlushedChunksProps) => {
       return React.createElement(
         'script',
         {
+          key: chunk,
           src: chunk,
           async: true,
         },
@@ -44,6 +45,7 @@ export const FlushedChunks = ({ chunks }: FlushedChunksProps) => {
       return React.createElement(
         'link',
         {
+          key: chunk,
           href: chunk,
           rel: 'stylesheet',
         },


### PR DESCRIPTION
This fixes the "Each child in a list should have a unique "key" prop" warning.