### PR TITLE
Move remote-delegate logic into utilities

### DIFF
--- a/apps/3000-home/next.config.js
+++ b/apps/3000-home/next.config.js
@@ -16,46 +16,46 @@ const nextConfig = {
     const { isServer } = options;
 
     const remotes = {
-      //     shop: `internal ./remote-delegate.js?remote=shop@http://localhost:3001/_next/static/${
-      //         isServer ? 'ssr' : 'chunks'
-      //       }/remoteEntry.js`,
-      //       checkout: `internal ./remote-delegate.js?remote=checkout@http://localhost:3002/_next/static/${
-      //         isServer ? 'ssr' : 'chunks'
-      //       }/remoteEntry.js`,
-      shop: `shop@http://localhost:3001/_next/static/${
+      shop: `internal ./remote-delegate.js?remote=shop@http://localhost:3001/_next/static/${
         isServer ? 'ssr' : 'chunks'
       }/remoteEntry.js`,
-      checkout: `checkout@http://localhost:3002/_next/static/${
+      checkout: `internal ./remote-delegate.js?remote=checkout@http://localhost:3002/_next/static/${
         isServer ? 'ssr' : 'chunks'
       }/remoteEntry.js`,
+      // shop: `shop@http://localhost:3001/_next/static/${
+      //   isServer ? 'ssr' : 'chunks'
+      // }/remoteEntry.js`,
+      // checkout: `checkout@http://localhost:3002/_next/static/${
+      //   isServer ? 'ssr' : 'chunks'
+      // }/remoteEntry.js`,
     };
 
-      config.plugins.push(
-        new NextFederationPlugin({
-          name: 'home_app',
-          filename: 'static/chunks/remoteEntry.js',
-          remotes: {
-            shop: remotes.shop,
-            checkout: remotes.checkout,
-          },
-          exposes: {
-            './SharedNav': './components/SharedNav',
-            './menu': './components/menu',
-          },
-          shared: {
-            lodash: {},
-            antd: {},
-          },
-          extraOptions: {
-            automaticAsyncBoundary: true,
-            exposePages: true,
-            enableImageLoaderFix: true,
-            enableUrlLoaderFix: true,
-            skipSharingNextInternals: false,
-            automaticPageStitching: true,
-          },
-        })
-      );
+    config.plugins.push(
+      new NextFederationPlugin({
+        name: 'home_app',
+        filename: 'static/chunks/remoteEntry.js',
+        remotes: {
+          shop: remotes.shop,
+          checkout: remotes.checkout,
+        },
+        exposes: {
+          './SharedNav': './components/SharedNav',
+          './menu': './components/menu',
+        },
+        shared: {
+          lodash: {},
+          antd: {},
+        },
+        extraOptions: {
+          automaticAsyncBoundary: true,
+          exposePages: true,
+          enableImageLoaderFix: true,
+          enableUrlLoaderFix: true,
+          skipSharingNextInternals: false,
+          automaticPageStitching: true,
+        },
+      })
+    );
     return config;
   },
 };

--- a/apps/3000-home/remote-delegate.js
+++ b/apps/3000-home/remote-delegate.js
@@ -1,30 +1,18 @@
+import { importDelegatedModule } from '@module-federation/utilities';
+
 module.exports = new Promise((resolve, reject) => {
-  if(!global.__remote_scope__) {
-    // create a global scope for container, similar to how remotes are set on window in the browser
-    global.__remote_scope__ = {
-      _config: {},
-    }
-  }
-  console.log('Delegate being called for', __resourceQuery)
-  const currentRequest = new URLSearchParams(__resourceQuery).get('remote')
-  console.log(currentRequest)
-  const [containerGlobal, url] = currentRequest.split('@');
-  if(typeof window === 'undefined') {
-    global.__remote_scope__._config[global] = url
-  }
-  const __webpack_error__ = new Error()
-  __webpack_require__.l(
+  console.log('Delegate being called for', __resourceQuery);
+  const currentRequest = new URLSearchParams(__resourceQuery).get('remote');
+  console.log(currentRequest);
+
+  const [global, url] = currentRequest.split('@');
+
+  importDelegatedModule({
+    global,
     url,
-    function (event) {
-      const container = typeof window === 'undefined' ? global.__remote_scope__[containerGlobal] : window[containerGlobal];
-      console.log('delegate resolving', container)
-      if (typeof container !== 'undefined') return resolve(container);
-      var realSrc = event && event.target && event.target.src;
-      __webpack_error__.message = 'Loading script failed.\\n(' + event.message + ': ' + realSrc + ')';
-      __webpack_error__.name = 'ScriptExternalLoadError';
-      __webpack_error__.stack = event.stack;
-      reject(__webpack_error__);
-    },
-    containerGlobal,
-  );
-})
+  })
+    .then((container) => {
+      resolve(container);
+    })
+    .catch((err) => reject(err));
+});


### PR DESCRIPTION
Move webpack_require calls from remote-delegates into the utilities, attempting to make injectScript a bit simpler, but provide a separate entry point for importDelegateModules.

Open to refactoring this a bit differently, I did not immediately know how to test injectScript outside of testing the next sample apps.