### PR TITLE
Typescript - ensure consistent file paths

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -85,7 +85,7 @@ export class TypescriptCompiler {
     );
 
     const pathWithExt = path.resolve(normalizedRootDir, filenameWithExt);
-    return pathWithExt.replace(/\\/g, '/');
+    return path.normalize(pathWithExt);
   }
 
   private createHost(exposeSrcToDestMap: Record<string, string>) {
@@ -112,7 +112,7 @@ export class TypescriptCompiler {
       );
 
       // create exports matching the `exposes` config
-      const sourceFilename = sourceFiles?.[0].fileName || '';
+      const sourceFilename = path.normalize(sourceFiles?.[0].fileName || '');
       const exposedDestFilePath = exposeSrcToDestMap[sourceFilename];
 
       // create reexport file only if the file was marked for exposing

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -85,7 +85,7 @@ export class TypescriptCompiler {
     );
 
     const pathWithExt = path.resolve(normalizedRootDir, filenameWithExt);
-    return pathWithExt;
+    return pathWithExt.replace(/\\/g, '/');
   }
 
   private createHost(exposeSrcToDestMap: Record<string, string>) {
@@ -132,7 +132,7 @@ export class TypescriptCompiler {
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
 
         this.tsDefinitionFilesObj[normalizedExposedDestFilePath] = reexport;
-        
+
         // reuse originalWriteFile as it creates folders if they don't exist
         originalWriteFile(
           normalizedExposedDestFilePath,


### PR DESCRIPTION
Windows machines resolve paths with a separator of '\\', this causes a miss in the exposed component map in the TypescriptCompiler. This PR will replace '\\' with '/' for the exposed component map. Without the fix the exposed component was never generated.