### PR TITLE
Fix/typescript import remote types

### DIFF
--- a/apps/react-ts-host/module-federation.config.js
+++ b/apps/react-ts-host/module-federation.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {import('@nrwl/react/module-federation').ModuleFederationConfig}
+ * @type {import('@nrwl/devkit').ModuleFederationConfig}
  **/
 const moduleFederationConfig = {
   name: 'react-ts-host',

--- a/apps/react-ts-host/webpack.config.prod.js
+++ b/apps/react-ts-host/webpack.config.prod.js
@@ -4,7 +4,7 @@ const { withModuleFederation } = require('@nrwl/react/module-federation');
 const baseConfig = require('./module-federation.config');
 
 /**
- * @type {import('@nrwl/react/module-federation').ModuleFederationConfig}
+ * @type {import('@nrwl/devkit').ModuleFederationConfig}
  **/
 const prodConfig = {
   ...baseConfig,

--- a/apps/react-ts-remote/module-federation.config.js
+++ b/apps/react-ts-remote/module-federation.config.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 /**
- * @type {import('@nrwl/react/module-federation').ModuleFederationConfig}
+ * @type {import('@nrwl/devkit').ModuleFederationConfig}
  **/
 const moduleFederationConfig = {
   name: 'react-ts-remote',

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -85,7 +85,7 @@ export class TypescriptCompiler {
     );
 
     const pathWithExt = path.resolve(normalizedRootDir, filenameWithExt);
-    return pathWithExt.replace(/\\/g, '/');
+    return path.normalize(pathWithExt);
   }
 
   private createHost(exposeSrcToDestMap: Record<string, string>) {
@@ -112,7 +112,7 @@ export class TypescriptCompiler {
       );
 
       // create exports matching the `exposes` config
-      const sourceFilename = sourceFiles?.[0].fileName || '';
+      const sourceFilename = path.normalize(sourceFiles?.[0].fileName || '');
       const exposedDestFilePath = exposeSrcToDestMap[sourceFilename];
 
       // create reexport file only if the file was marked for exposing

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -85,7 +85,7 @@ export class TypescriptCompiler {
     );
 
     const pathWithExt = path.resolve(normalizedRootDir, filenameWithExt);
-    return pathWithExt;
+    return pathWithExt.replace(/\\/g, '/');
   }
 
   private createHost(exposeSrcToDestMap: Record<string, string>) {
@@ -132,7 +132,7 @@ export class TypescriptCompiler {
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
 
         this.tsDefinitionFilesObj[normalizedExposedDestFilePath] = reexport;
-        
+
         // reuse originalWriteFile as it creates folders if they don't exist
         originalWriteFile(
           normalizedExposedDestFilePath,

--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -1,4 +1,8 @@
-import type { WebpackRequire, WebpackShareScopes } from '../types';
+import type {
+  AsyncContainer,
+  WebpackRequire,
+  WebpackShareScopes,
+} from '../types';
 
 type RemoteUrl = string | (() => Promise<string>);
 
@@ -72,7 +76,8 @@ export const importRemote = async <T>({
   remoteEntryFileName = REMOTE_ENTRY_FILE,
   bustRemoteEntryCache = true,
 }: ImportRemoteOptions): Promise<T> => {
-  if (!window[scope]) {
+  const remoteScope = scope as unknown as number;
+  if (!window[remoteScope]) {
     let remoteUrl = '';
 
     if (typeof url === 'string') {
@@ -90,21 +95,23 @@ export const importRemote = async <T>({
       ),
       initSharing(),
     ]);
-    if (!window[scope]) {
+    if (!window[remoteScope]) {
       throw new Error(
         `Remote loaded successfully but ${scope} could not be found! Verify that the name is correct in the Webpack configuration!`
       );
     }
     // Initialize the container to get shared modules and get the module factory:
     const [, moduleFactory] = await Promise.all([
-      initContainer(window[scope]),
-      window[scope].get(module.startsWith('./') ? module : `./${module}`),
+      initContainer(window[remoteScope]),
+      (
+        await (window[remoteScope] as unknown as AsyncContainer)
+      ).get(module.startsWith('./') ? module : `./${module}`),
     ]);
     return moduleFactory();
   } else {
-    const moduleFactory = await window[scope].get(
-      module.startsWith('./') ? module : `./${module}`
-    );
+    const moduleFactory = (
+      await (window[remoteScope] as unknown as AsyncContainer)
+    ).get(module.startsWith('./') ? module : `./${module}`);
     return moduleFactory();
   }
 };

--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -1,5 +1,5 @@
 import type {
-  AsyncContainer,
+  WebpackRemoteContainer,
   WebpackRequire,
   WebpackShareScopes,
 } from '../types';
@@ -103,14 +103,14 @@ export const importRemote = async <T>({
     // Initialize the container to get shared modules and get the module factory:
     const [, moduleFactory] = await Promise.all([
       initContainer(window[remoteScope]),
-      (
-        await (window[remoteScope] as unknown as AsyncContainer)
-      ).get(module.startsWith('./') ? module : `./${module}`),
+      (window[remoteScope] as unknown as WebpackRemoteContainer).get(
+        module.startsWith('./') ? module : `./${module}`
+      ),
     ]);
     return moduleFactory();
   } else {
-    const moduleFactory = (
-      await (window[remoteScope] as unknown as AsyncContainer)
+    const moduleFactory = await (
+      window[remoteScope] as unknown as WebpackRemoteContainer
     ).get(module.startsWith('./') ? module : `./${module}`);
     return moduleFactory();
   }


### PR DESCRIPTION
Building the react-ts-* apps in the repo cause typescript compilation errors, this fixes the types so that they compile. The examples may need to be updated a bit more or expanded