### PR TITLE
fix(typescript): set vue-tsc as optional peer dep

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -19,9 +19,13 @@
     "Pavan Divi <pavan.divi@outlook.com> (https://github.com/pavandv)"
   ],
   "peerDependencies": {
+    "typescript": "*",
     "vue-tsc": "^1.0.24",
-    "webpack": "^5.75.0",
-    "react": "^17 || ^18",
-    "next": "^12 || ^13"
+    "webpack": "^5.75.0"
+  },
+  "peerDependenciesMeta": {
+    "vue-tsc": {
+      "optional": true
+    }
   }
 }

--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -1,8 +1,16 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import ts from 'typescript';
-import vueTs from 'vue-tsc';
 import path from 'path';
 import fs from 'fs';
+
+import type { _Program } from 'vue-tsc'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let vueTs: any;
+try {
+  vueTs = require('vue-tsc');
+} catch {
+  // vue-tsc is an optional dependency.
+}
 
 import { Logger } from '@module-federation/utilities';
 
@@ -77,9 +85,13 @@ export class TypescriptCompiler {
 
     switch (compiler) {
       case 'vue-tsc':
-        return vueTs.createProgram(programOptions);
-        break;
-
+        if (!vueTs) {
+          this.logger.error(
+            'ERROR: vue-tsc must be installed when using the vue-tsc compiler option'
+          );
+          process.exit(1);
+        }
+        return vueTs.createProgram(programOptions) as _Program;
       case 'tsc':
       default:
         return ts.createProgram(programOptions);

--- a/packages/typescript/src/types/index.ts
+++ b/packages/typescript/src/types/index.ts
@@ -13,7 +13,7 @@ export interface FederatedTypesPluginOptions {
   typescriptCompiledFolderName?: string;
   additionalFilesToCompile?: string[];
   /** @default 'tsc' */
-  compiler: 'tsc' | 'vue-tsc';
+  compiler?: 'tsc' | 'vue-tsc';
 }
 
 export interface TypesStatsJson {


### PR DESCRIPTION
Change `vue-tsc` to be an optional peer dep otherwise react projects would have to include this unneeded dep.  I've also removed `next` and `react` from the peer deps since they both aren't a requirement to use this lib.