### PR TITLE
fix(typescript): fix import path for generated dts in Windows

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -159,8 +159,15 @@ export class TypescriptCompiler {
           filepath
         );
         // add ./ so it's always relative, remove d.ts because it's not needed and can throw warnings
-        const importPath =
+        let importPath =
           './' + relativePathToCompiledFile.replace(/\.d\.ts$/, '');
+
+        // If we're on Windows, need to convert "\" to "/" in the import path since it
+        // was derived from platform-specific file system path.
+        if (path.sep === '\\') {
+          importPath = importPath.replaceAll(path.sep, '/');
+        }
+
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;
 
         this.tsDefinitionFilesObj[normalizedExposedDestFilePath] = reexport;


### PR DESCRIPTION
This fixes an issue where the import paths in the generated re-export dts file are incorrect on Windows.  The code checks if the platform-specific separator is a backslash, then replaces it with forward slashes so the imports are correct.

This is the output on `@module-federation/typescript` v2.2.0:

```
export * from './_types\Button';
export { default } from './_types\Button';
```

With fix:

```
export * from './_types/Button';
export { default } from './_types/Button';
```