### PR TITLE
chore: fix build

### DIFF
--- a/packages/nextjs-mf/utils/build-utils.ts
+++ b/packages/nextjs-mf/utils/build-utils.ts
@@ -44,7 +44,8 @@ const IsomorphicRemoteTemplate = function () {
   if (index <= 0 || index === urlAndGlobal.length - 1) {
     throw new Error(`Invalid request "${urlAndGlobal}"`);
   }
-  var remote = {
+
+  const remote = {
     url: urlAndGlobal.substring(index + 1),
     global: urlAndGlobal.substring(0, index) as unknown as number, // this casting to satisfy TS
   };
@@ -89,9 +90,9 @@ const IsomorphicRemoteTemplate = function () {
           }
         }
 
-        var errorType =
+        const errorType =
           event && (event.type === 'load' ? 'missing' : event.type);
-        var realSrc =
+        const realSrc =
           event && event.target && (event.target as HTMLScriptElement).src;
 
         __webpack_error__.message =
@@ -113,8 +114,8 @@ const IsomorphicRemoteTemplate = function () {
     );
   })
     .then(function () {
-      //@ts-ignore
       const globalScope =
+        //@ts-ignore
         typeof window !== 'undefined' ? window : global.__remote_scope__;
       const remoteGlobal = globalScope[
         remote.global


### PR DESCRIPTION
The prettier formatting shifted this code `typeof window !== 'undefined' ? window : global.__remote_scope__;` into a new line, so the existing `@ts-ignore` directive misses it.  This causes the build to fail.

This PR fixes this and a couple random `var` declarations.