### PR TITLE
fix(typescript): fix Node 14 compatibility

### DIFF
--- a/packages/typescript/src/lib/download.ts
+++ b/packages/typescript/src/lib/download.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import fetch from 'node-fetch';
 import path from 'path';
-import { pipeline } from 'stream/promises';
+import util from 'util';
+import { pipeline } from 'stream';
+
+const pipelineAsync = util.promisify(pipeline);
 
 export interface DownloadOptions {
   /**
@@ -43,7 +46,7 @@ export default async function download(options: DownloadOptions) {
     recursive: true,
   });
 
-  await pipeline(
+  await pipelineAsync(
     response.body,
     fs.createWriteStream(fileDest, {
       flags: 'w',


### PR DESCRIPTION
Fixes #595

This falls back to the `pipeline` API that's available in Node 14