### PR TITLE
fix: include src folder in paths validation

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
@@ -126,13 +126,12 @@ export class NextFederationPlugin {
       };
     }
 
+    const allowedPaths = ['pages/', 'app/', 'src/pages/', 'src/app/']
+
     //patch next
     compiler.options.module.rules.push({
       test(req: string) {
-        if (
-          req.includes(path.join(compiler.context, 'pages/')) ||
-          req.includes(path.join(compiler.context, 'app/'))
-        ) {
+        if (allowedPaths.some(p => req.includes(path.join(compiler.context, p)))) {
           return /\.(js|jsx|ts|tsx|md|mdx|mjs)$/i.test(req);
         }
         return false;
@@ -150,10 +149,7 @@ export class NextFederationPlugin {
           test(req: string) {
             if (isServer) {
               // server has no common chunk or entry to hoist into
-              if (
-                req.includes(path.join(compiler.context, 'pages/')) ||
-                req.includes(path.join(compiler.context, 'app/'))
-              ) {
+              if (allowedPaths.some(p => req.includes(path.join(compiler.context, p)))) {
                 return /\.(js|jsx|ts|tsx|md|mdx|mjs)$/i.test(req);
               }
             }
@@ -183,10 +179,7 @@ export class NextFederationPlugin {
     if (this._extraOptions.automaticAsyncBoundary) {
       compiler.options.module.rules.push({
         test: (request: string) => {
-          if (
-            request.includes(path.join(compiler.context, 'pages/')) ||
-            request.includes(path.join(compiler.context, 'app/'))
-          ) {
+          if (allowedPaths.some(p => request.includes(path.join(compiler.context, p)))) {
             return /\.(js|jsx|ts|tsx|md|mdx|mjs)$/i.test(request);
           }
           return false;


### PR DESCRIPTION
Motivation:
When the project uses the 'src' folder, the NextFederationPlugin does not include the 'include-defaults.ts'! 
If we try to use a component like 'next/link' for example, it causes a runtime error in the application.

`Unhandled Runtime Error
Error: Shared module next/link doesn't exist in shared scope default`

Note:
Using the 'src' folder in the project is defined in the `yarn create next-app` wizard:
`Would you like to use `src/` directory with this project? › No / Yes`