### PR TITLE
fix: exclude next middleware from async boundary loader

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
@@ -184,7 +184,7 @@ export class NextFederationPlugin {
           }
           return false;
         },
-        exclude: [/node_modules/, /_document/, /_middleware/, /pages[\\/]api/],
+        exclude: [/node_modules/, /_document/, /_middleware/,/pages[\\/]middleware/, /pages[\\/]api/],
         resourceQuery: (query) => !query.includes('hasBoundary'),
         loader: path.resolve(__dirname, '../loaders/async-boundary-loader'),
       });


### PR DESCRIPTION
This is an update to apply the exclude rule to /pages/middleware