### PR TITLE
fix: Add 'react/jsx-dev-runtime' to share scope

### DIFF
--- a/packages/nextjs-mf/src/internal.ts
+++ b/packages/nextjs-mf/src/internal.ts
@@ -28,6 +28,10 @@ export const DEFAULT_SHARE_SCOPE: SharedObject = {
     singleton: true,
     requiredVersion: false,
   },
+  'react/jsx-dev-runtime': {
+    singleton: true,
+    requiredVersion: false,
+  },
   'react-dom': {
     singleton: true,
     requiredVersion: false,


### PR DESCRIPTION
This enables us to have both the host and the remote be running in dev mode.