### PR TITLE
feat(nextjs-mf): dynamic remote page for dynamic route

### DIFF
--- a/apps/3000-home/pages/[...slug].js
+++ b/apps/3000-home/pages/[...slug].js
@@ -1,0 +1,9 @@
+import { injectScript } from '@module-federation/utilities'
+import { createDynamicFederatedPage } from '@module-federation/nextjs-mf/utils'
+
+const { Page, getServerSideProps } = createDynamicFederatedPage({
+  injectScriptReplacement: injectScript
+})
+
+export { getServerSideProps }
+export default Page;

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "6.4.0",
+  "version": "6.4.1-beta.dynamic.1",
   "license": "MIT",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/nextjs-mf/utils/createDynamicFederatedPage.ts
+++ b/packages/nextjs-mf/utils/createDynamicFederatedPage.ts
@@ -1,0 +1,133 @@
+import * as React from 'react'
+import { injectScript, getModule } from '@module-federation/utilities'
+import type { RemoteData } from '@module-federation/utilities'
+import { useRouter } from 'next/router'
+import { GetServerSideProps, Redirect } from 'next/types'
+
+export type ResolvedPathObject = {
+  remoteContainer: string | RemoteData,
+  modulePath: string,
+  /**
+   * In case of custom path resolver for parametrized routes,
+   * this is the key to the remote module.
+   * Example: path = '/storage/123', resolvedPath = '/storage/*'
+   */
+  resolvedPath: string
+}
+
+export type PathResolver = (path: string) => ResolvedPathObject
+
+function defaultPathResolver(path: string): ResolvedPathObject {
+  const trimmedPath = path.replace(/^\/+/, '')
+  const slashIndex = trimmedPath.indexOf('/')
+  const remoteContainer = slashIndex > -1 ? trimmedPath.substring(0, slashIndex) : trimmedPath
+  const modulePath = slashIndex > -1 ? trimmedPath.substring(slashIndex) : '/index'
+
+  return {
+    remoteContainer,
+    modulePath: `.${modulePath}`,
+    resolvedPath: path,
+  }
+}
+
+export type ErrorHandler = (error: unknown) => { redirect: Redirect } | { notFound: true }
+
+function defaultErrorHandler(error: unknown): { redirect: Redirect } | { notFound: true } {
+  console.error(error)
+  return {
+    notFound: true,
+  }
+}
+
+/**
+ * This function creates a dynamic page that is loaded from a remote defined by the path.
+ * @typedef {Object} CreateDynamicFederatedPageOptions
+ * @property pathResolver - function to obtain remote container name and module path from the page path, by default it's a simple path splitting
+ * @property errorHandler - function to handle errors, by default it just logs the error and returns 404
+ * @property suspenseFallback - fallback to render while remote module is loading
+ * TODO: remove injectScriptReplacement when it's fixed in @module-federation/utilities
+ * @property injectScriptReplacement - replacement for @module-federation/utilities/injectScript, which import is broken in @module-federation/nextjs-mf v6.4.0
+ */
+interface CreateDynamicFederatedPageOptions {
+  pathResolver?: PathResolver,
+  errorHandler?: ErrorHandler,
+  suspenseFallback?: React.ReactNode
+  injectScriptReplacement?: typeof injectScript,
+}
+
+export function createDynamicFederatedPage({
+  pathResolver = defaultPathResolver,
+  errorHandler = defaultErrorHandler,
+  suspenseFallback = null,
+  injectScriptReplacement = injectScript,
+}: CreateDynamicFederatedPageOptions = {}) {
+  const getRemoteModule = async (path: string) => {
+    const { remoteContainer, modulePath } = pathResolver(path)
+    const remoteContainerGlobal = typeof remoteContainer === 'string' ? remoteContainer : remoteContainer.global
+
+    // getModule() doesn't work on server-side
+    // and doesn't work on first render on client-side
+    if (typeof window === 'undefined' || !(window as any)[remoteContainerGlobal]) {
+      const container = await injectScriptReplacement(remoteContainer)
+      // @ts-ignore
+      return await container.get(modulePath)?.then((factory) => factory())
+    } else {
+      return await getModule({
+        remoteContainer,
+        modulePath,
+      })
+    }
+  }
+
+  const DynamicComponent = ({ props, path }: { props: React.Attributes, path: string }) => {
+    const Component = React.useMemo(() => {
+      return React.lazy(() => getRemoteModule(path))
+    }, [path])
+
+    return React.createElement(React.Suspense,
+      { fallback: suspenseFallback },
+      React.createElement(Component, props),
+    )
+  }
+
+  const Page = (props: React.Attributes) => {
+    const router = useRouter()
+    const path = router.asPath.split('?')[0]
+
+    // this is a hack to prevent infinity re-rendering
+    // when navigating between pages with the same path and different slug
+    const [oldPath, setOldPath] = React.useState(path)
+    React.useEffect(() => {
+      setOldPath(path)
+    }, [path])
+    if (path !== oldPath) {
+      return null
+    }
+    // end hack
+
+    return React.createElement(DynamicComponent, { props, path })
+  }
+
+  const getServerSideProps: GetServerSideProps = async (ctx) => {
+    const path = ctx.resolvedUrl.split('?')[0]
+
+    try {
+      const remoteModule = await getRemoteModule(path)
+
+      if (typeof remoteModule.getServerSideProps === 'function') {
+        return await remoteModule.getServerSideProps(ctx)
+      }
+
+      return {
+        props: {},
+      }
+    } catch (e) {
+      return errorHandler(e)
+    }
+  }
+
+  return {
+    Page,
+    getServerSideProps,
+  }
+}

--- a/packages/nextjs-mf/utils/index.ts
+++ b/packages/nextjs-mf/utils/index.ts
@@ -5,6 +5,7 @@ export {
 } from '@module-federation/utilities';
 // @ts-ignore
 export { flushChunks } from '@module-federation/node/utils';
+export { createDynamicFederatedPage } from './createDynamicFederatedPage';
 
 export const revalidate = () => {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
### Description:

This pull request introduces a new utility function, `createDynamicFederatedPage`, which allows developers to load remote pages based on the current path.

#### The main features of this implementation include:

- Customizable path resolution: Developers can provide a custom pathResolver to determine how to obtain the remote container name and module path from the page path. The default implementation simply splits the path.
- Error handling: A custom errorHandler function can be provided to handle errors that occur when loading remote modules. By default, the error is logged, and a 404 page is returned.
- Suspense fallback: A suspenseFallback can be specified to render while the remote module is loading.
- Compatibility with server-side rendering: The getServerSideProps function is provided to handle server-side data fetching for the remote module.

Please review the changes and provide any feedback or suggestions.

re #810