### PR TITLE
Possibility of adding relative urls to remotes

### DIFF
--- a/packages/nextjs-mf/src/internal.ts
+++ b/packages/nextjs-mf/src/internal.ts
@@ -107,7 +107,13 @@ export const generateRemoteTemplate = (
   url: string,
   global: any
 ) => `new Promise(function (resolve, reject) {
-    var url = new URL(${JSON.stringify(url)});
+    // In case of being a relative url add the base
+    var url_s = ${JSON.stringify(url)};
+    if (url_s.charAt(0)=='/') {
+      var url = new URL(url_s, window.location.href);
+    } else {
+      var url = new URL(url_s);
+    }
     url.searchParams.set('t', Date.now());
     var __webpack_error__ = new Error();
     if(!window.remoteLoading) {

--- a/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
+++ b/packages/node/src/plugins/LoadFileChunkLoadingRuntimeModule.ts
@@ -308,7 +308,12 @@ class ReadFileChunkLoadingRuntimeModule extends RuntimeModule {
                                 (acc, remote) => {
                                   //TODO: need to handle all other cases like when remote is not a @ syntax string
                                   const [global, url] = remote.split('@');
-                                  acc[global] = url;
+                                  // In case of being a relative url add the base
+                                  if (url.charAt(0)=='/') {
+                                    acc[global] = 'window.location.href + url';
+                                  } else {
+                                    acc[global] = url;
+                                  }
                                   return acc;
                                 },
                                 {} as Record<string, string>

--- a/packages/node/src/plugins/loadScript.ts
+++ b/packages/node/src/plugins/loadScript.ts
@@ -73,7 +73,12 @@ export const executeLoadTemplate = `
               }
             }
           };
-          global.__remote_scope__._config[name] = url;
+          // In case of being a relative url add the base
+          if (url.charAt(0)=='/') {
+            global.__remote_scope__._config[name] = 'window.location.href + url';
+          } else {
+            global.__remote_scope__._config[name] = url;
+          }
         }
         callback(global.__remote_scope__[name]);
       } catch (e) {


### PR DESCRIPTION
The idea is to be able to define the remote urls in a relative way: 

remotes: {
        app1: 'app1@/remoteApp1/remoteEntry.js',
},

In this way we will have the microfrontends in the same domain. Then, by setting the appropriate basePaths in each app, I can define the URLs at runtime via haproxy or another reverse proxy.