### PR TITLE
fix: externalization and missing runtime chunks

### DIFF
--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [6.4.1-rc.3](https://github.com/module-federation/nextjs-mf/compare/nextjs-mf-6.4.1-rc.2...nextjs-mf-6.4.1-rc.3) (2023-05-18)
+
+
+
 ## [6.4.1-rc.2](https://github.com/module-federation/nextjs-mf/compare/nextjs-mf-6.4.1-rc.1...nextjs-mf-6.4.1-rc.2) (2023-05-17)
 
 

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [6.4.1-rc.4](https://github.com/module-federation/nextjs-mf/compare/nextjs-mf-6.4.1-rc.3...nextjs-mf-6.4.1-rc.4) (2023-05-18)
+
+
+### Bug Fixes
+
+* resolve build hanging issue ([e352e7e](https://github.com/module-federation/nextjs-mf/commit/e352e7e88a050857d1500025313518956ee11d08))
+
+
+
 ## [6.4.1-rc.3](https://github.com/module-federation/nextjs-mf/compare/nextjs-mf-6.4.1-rc.2...nextjs-mf-6.4.1-rc.3) (2023-05-18)
 
 

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "6.4.1-rc.2",
+  "version": "6.4.1-rc.3",
   "license": "MIT",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "6.4.1-rc.3",
+  "version": "6.4.1-rc.4",
   "license": "MIT",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/nextjs-mf/src/internal.ts
+++ b/packages/nextjs-mf/src/internal.ts
@@ -70,7 +70,7 @@ export const DEFAULT_SHARE_SCOPE: SharedObject = {
     singleton: true,
     requiredVersion: false,
     eager: true,
-    import: undefined,
+    import: false,
   },
   'styled-jsx': {
     requiredVersion: false,

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -145,7 +145,9 @@ export function handleServerExternals(
         // make sure we dont screw up package names that start with react
         // like react-carousel or react-spring
         req.startsWith('react/') ||
-        req === 'react'
+        req.startsWith('react-dom/') ||
+        req === 'react' ||
+        req === 'react-dom'
       ) {
         return fromNext;
       }

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -177,10 +177,8 @@ export function configureServerCompilerOptions(compiler: Compiler): void {
     ...compiler.options.node,
     global: false,
   };
-  // Set chunkIds optimization to 'named'
-  // compiler.options.optimization.chunkIds = 'named'; // for debugging
-  // compiler.options.optimization.minimize = false;
-  // compiler.options.optimization.moduleIds = 'named';
+  // Build will hang without this. Likely something in my plugin
+  compiler.options.optimization.chunkIds = 'named'; // for debugging
 
   // Disable split chunks to prevent conflicts from occurring in the graph
   // TODO on the `compiler.options.optimization.splitChunks` line would be to find a way to only opt out chunks/modules related to module federation from chunk splitting logic.

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -122,6 +122,13 @@ export function handleServerExternals(
         return;
       }
 
+      // seems to cause build issues at lululemon
+      // nobody else seems to run into this issue
+      // #JobSecurity
+      if (ctx.request && ctx.request.includes('react/jsx-runtime')) {
+        return 'commonjs ' + ctx.request;
+      }
+
       // Call the original externals function and retrieve the result
       // @ts-ignore
       const fromNext = await originalExternals(ctx, callback);
@@ -133,11 +140,17 @@ export function handleServerExternals(
 
       // If the module is from Next.js or React, return the original result
       const req = fromNext.split(' ')[1];
-      if (req.startsWith('next') || req.startsWith('react')) {
+      if (
+        req.startsWith('next') ||
+        // make sure we dont screw up package names that start with react
+        // like react-carousel or react-spring
+        req.startsWith('react/') ||
+        req === 'react'
+      ) {
         return fromNext;
       }
 
-      // Otherwise, return null
+      // Otherwise, return (null) to treat the module as internalizable
       return;
     };
   }
@@ -163,7 +176,9 @@ export function configureServerCompilerOptions(compiler: Compiler): void {
     global: false,
   };
   // Set chunkIds optimization to 'named'
-  compiler.options.optimization.chunkIds = 'named'; // for debugging
+  // compiler.options.optimization.chunkIds = 'named'; // for debugging
+  // compiler.options.optimization.minimize = false;
+  // compiler.options.optimization.moduleIds = 'named';
 
   // Disable split chunks to prevent conflicts from occurring in the graph
   // TODO on the `compiler.options.optimization.splitChunks` line would be to find a way to only opt out chunks/modules related to module federation from chunk splitting logic.

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.14.7-rc.4](https://github.com/module-federation/nextjs-mf/compare/node-0.14.7-rc.3...node-0.14.7-rc.4) (2023-05-18)
+
+
+
 ## [0.14.7-rc.3](https://github.com/module-federation/nextjs-mf/compare/node-0.14.7-rc.2...node-0.14.7-rc.3) (2023-05-18)
 
 

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [0.14.7-rc.3](https://github.com/module-federation/nextjs-mf/compare/node-0.14.7-rc.2...node-0.14.7-rc.3) (2023-05-18)
+
+
+
 ## [0.14.7-rc.2](https://github.com/module-federation/nextjs-mf/compare/node-0.14.7-rc.1...node-0.14.7-rc.2) (2023-05-17)
 
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "0.14.7-rc.2",
+  "version": "0.14.7-rc.3",
   "type": "commonjs",
   "main": "src/index.js",
   "exports": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "0.14.7-rc.3",
+  "version": "0.14.7-rc.4",
   "type": "commonjs",
   "main": "src/index.js",
   "exports": {

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [1.7.6-rc.3](https://github.com/module-federation/nextjs-mf/compare/utils-1.7.6-rc.2...utils-1.7.6-rc.3) (2023-05-18)
+
+
+
 ## [1.7.6-rc.2](https://github.com/module-federation/nextjs-mf/compare/utils-1.7.6-rc.1...utils-1.7.6-rc.2) (2023-05-17)
 
 

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file was generated using [@jscutlery/semver](https://github.com/jscutlery/semver).
 
+## [1.7.6-rc.4](https://github.com/module-federation/nextjs-mf/compare/utils-1.7.6-rc.3...utils-1.7.6-rc.4) (2023-05-18)
+
+
+
 ## [1.7.6-rc.3](https://github.com/module-federation/nextjs-mf/compare/utils-1.7.6-rc.2...utils-1.7.6-rc.3) (2023-05-18)
 
 

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "1.7.6-rc.2",
+  "version": "1.7.6-rc.3",
   "type": "commonjs",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/utilities",
-  "version": "1.7.6-rc.3",
+  "version": "1.7.6-rc.4",
   "type": "commonjs",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/packages/utilities/src/utils/common.ts
+++ b/packages/utilities/src/utils/common.ts
@@ -238,6 +238,7 @@ export const loadScript = (keyOrRuntimeRemoteItem: string | RuntimeRemote) => {
             };
           });
         },
+        //eslint-disable-next-line
         init: () => {},
       };
     });


### PR DESCRIPTION
This update focuses on resolving build issues and optimizing the handling of Next.js and React modules within the NextFederationPlugin. Various release candidate versions of nextjs-mf, node, and utils packages have been published to reflect these changes.

## Commits
 - fix: resolve build hanging issue
   - Enable 'named' value for optimization.chunkIds in apply-server-plugins.ts
   - Remove redundant comments in apply-server-plugins.ts
 - refactor: Improve handling of Next.js and React modules
   - Add conditions in apply-server-plugins.ts to handle modules starting with 'react-dom/'
   - Include 'react' and 'react-dom' as exact matches in apply-server-plugins.ts
 - fix: Resolve build issues at lululemon
   - Update import value for 'react/jsx-runtime' in DEFAULT_SHARE_SCOPE in internal.ts
   - Update handleServerExternals function in apply-server-plugins.ts to prevent build issues at lululemon
   - Configure server compiler options in apply-server-plugins.ts to handle node builds and prevent conflicts