### PR TITLE
fix: Add ./src/ export to package.json

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,7 +13,8 @@
     "./utils": {
       "import": "./src/utils/index.js",
       "require": "./src/utils/index.js"
-    }
+    },
+    "./src/": "./src/"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
This commit adds a new export to package.json for the ./src/ directory. This enables consumers of the package to import individual files from the 'src' directory more easily.

### packages/node/package.json

- Add './src/' export to 'exports' object