### PR TITLE
doc: Added more details to revalidate documentation

### DIFF
--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -129,6 +129,8 @@ revalidate().then((shouldReload) => {
 });
 ```
 
+*Note*: To ensure that changes made to files in remotes are picked up `revalidate`, you can set the remotes webpack [output.filename](https://webpack.js.org/configuration/output/#outputfilename) to `[name]-[contenthash].js` (or similar). This will cause the remoteEntry.js file to be regenerated with a unique hash every time a new build occurs. The revalidate method intelligently detects changes by comparing the hashes of the remoteEntry.js files. By incorporating [contenthash] into the remote's webpack configuration, you enable the shell to seamlessly incorporate the updated files from the remotes.
+
 **Hot reloading Express.js**
 
 Express has its own route stack, so reloading require cache will not be enough to reload the routes inside express.


### PR DESCRIPTION
Added more details to the revalidate documentation as the default webpack configuration, which does not hash development chunks, may cause the revalidate method not to work as developers expect.

Motivation: https://github.com/module-federation/universe/issues/843