### PR TITLE
fix(Utils): Unable to use importRemote util for root exported modules

### DIFF
--- a/packages/utilities/src/utils/importRemote.ts
+++ b/packages/utilities/src/utils/importRemote.ts
@@ -104,14 +104,14 @@ export const importRemote = async <T>({
     const [, moduleFactory] = await Promise.all([
       initContainer(window[remoteScope]),
       (window[remoteScope] as unknown as WebpackRemoteContainer).get(
-        module.startsWith('./') ? module : `./${module}`
+        (module === '.' || module.startsWith('./')) ? module : `./${module}`
       ),
     ]);
     return moduleFactory();
   } else {
     const moduleFactory = await (
       window[remoteScope] as unknown as WebpackRemoteContainer
-    ).get(module.startsWith('./') ? module : `./${module}`);
+    ).get((module === '.' || module.startsWith('./')) ? module : `./${module}`);
     return moduleFactory();
   }
 };


### PR DESCRIPTION
**Description:**
- Unable to use `importRemote` utility for importing root-level modules

**Example:**
```ts
// webpack.config
const moduleFederationConfig = {
   ....
   name: "MyRemoteComps",
   exposes: {
     ".": "src/remotes" // has index.ts that exports all components under the folder
  }
}

// at consuming end
const Comp1 = lazy(() =>
  importRemote({
    url: '<base_url>',
    scope: "MyRemoteComps",
    module: ".",
  }).then(m => m.Comp1)
);
  