### PR TITLE
fix use client issue https://github.com/module-federation/universe/issues/953

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin.ts
@@ -141,6 +141,7 @@ export class NextFederationPlugin {
     //patch next
     compiler.options.module.rules.push({
       test(req: string) {
+        if (isServer) return false;
         if (
           allowedPaths.some((p) => req.includes(path.join(compiler.context, p)))
         ) {


### PR DESCRIPTION
I'm not sure whether you'll consider this fix proper, but it works :) 

The basic idea is that some dependency of `nextjs-mf\src\include-defaults.js` requires the package `client-only` causing the error outlined in issue 953, so we don't include the patch file in server side builds. 

Side note I saw your [contributing guideline](https://github.com/module-federation/universe/blob/4216e3d433b585f4952c5da522232a92b207fc1e/CONTRIBUTING.md) and ran `npm run release:next` but for some reason Nx is attempting to version the utils package instead of nextjs-mf, not too familiar with Nx, is there maybe a configuration issue? 

Thanks! 