### PR TITLE
fix(nextjs-mf): update broken documentation

### DIFF
--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -28,9 +28,6 @@ You do not need to share these packages, sharing next internals yourself will ca
 <details>
 <summary> See DEFAULT_SHARE_SCOPE:</summary>
 
-<details>
-<summary> See DEFAULT_SHARE_SCOPE:</summary>
-
 ```ts
 export const DEFAULT_SHARE_SCOPE: SharedObject = {
   'next/dynamic': {
@@ -113,7 +110,7 @@ const SampleComponent = lazy(() => import('next2/sampleComponent'));
 
 To avoid hydration errors, use `React.lazy` instead of `next/dynamic` for lazy loading federated components.
 
-#### See the implementation here: https://github.com/module-federation/module-federation-examples/tree/master/nextjs/home/pages
+#### See the implementation here: https://github.com/module-federation/module-federation-examples/tree/master/nextjs-v13/home/pages
 
 With async boundary installed at the page level. You can then do the following
 


### PR DESCRIPTION
nextjs-mf documentation is actually broken because of an open `<details>` tag.

Also, a broken link is here for a long time now. I don’t really know which example should be linked, but I think the **nextjs-v13** one is accurate.

![image](https://github.com/module-federation/universe/assets/634146/b5bc88cc-0f37-4162-8650-6b99f16373ed)
