### PR TITLE
Fix: v7 API Routes

### DIFF
--- a/packages/nextjs-mf/src/plugins/container/InvertedContainerPlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/InvertedContainerPlugin.ts
@@ -168,7 +168,8 @@ class InvertedContainerPlugin {
               !renderContext?.debugId ||
               !compilation.chunkGraph.isEntryModule(renderContext) ||
               //@ts-ignore
-              renderContext?.rawRequest?.includes('pages/api')
+              renderContext?.rawRequest?.includes('pages/api') ||
+              renderContext?.layer === 'api'
             ) {
               // skip empty modules, container entry, and anything that doesnt have a moduleid or is not an entrypoint module.
               return source;


### PR DESCRIPTION
Our API Routes using the v7 version of the NextJS MF Plugin are failing with the following error:

```
ERROR    TypeError: Cannot read properties of undefined (reading 'then')
    at __webpack_exec__ (/var/task/.next/server/pages/api/config.js:972:60)
```

That happens because the build is including this template:

```
function(moduleId) { return __webpack_require__.own_remote.then(function() { return Promise.all([
	Promise.all(__webpack_require__.initRemotes),
	Promise.all(__webpack_require__.initConsumes)
]); }).then(function() { return __webpack_exec_proxy__(moduleId); }); }
```

Checking the code, for anything that has `pages/api` (i.e. an API Route) we should not be adding this template, but instead returning the source directly. While investigating why the current check is not passing (`renderContext.rawRequest.includes('pages/api')`) I found out it's because my API Route is a ConcatenatedModule so it does not contain a `rawRequest` property, that sits inside another object.

API Routes do have an identifier of a `layer` which is `api`.  I'm not 100% sure if this property is only used there, but when testing a build it seems that only API paths have this layer. After adding this check, the built API code does not have that template anymore.

Still have to test a deployment after this change.