### PR TITLE
fix: Update TypescriptCompiler.ts

### DIFF
--- a/packages/typescript/src/lib/TypescriptCompiler.ts
+++ b/packages/typescript/src/lib/TypescriptCompiler.ts
@@ -164,7 +164,7 @@ export class TypescriptCompiler {
         // If we're on Windows, need to convert "\" to "/" in the import path since it
         // was derived from platform-specific file system path.
         if (path.sep === '\\') {
-          importPath = importPath.replaceAll(path.sep, '/');
+          importPath = importPath.split(path.sep).join('/');
         }
 
         const reexport = `export * from '${importPath}';\nexport { default } from '${importPath}';`;


### PR DESCRIPTION
The `replaceAll()` method crashes on Node versions below 15.
fixes https://github.com/module-federation/universe/issues/1177