### PR TITLE
Enhanced - remove import require statements for swc interop

### DIFF
--- a/packages/enhanced/.swcrc
+++ b/packages/enhanced/.swcrc
@@ -17,7 +17,8 @@
   "module": {
     "type": "commonjs",
     "strict": true,
-    "noInterop": true
+    "noInterop": false,
+    "importInterop": "swc"
   },
   "sourceMaps": true,
   "exclude": [

--- a/packages/enhanced/src/lib/container/ContainerEntryDependency.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryDependency.ts
@@ -4,10 +4,8 @@
 */
 
 import { ExposeOptions } from './ContainerEntryModule';
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
-//@ts-ignore
-import Dependency = require('webpack/lib/Dependency');
+import makeSerializable from 'webpack/lib/util/makeSerializable';
+import Dependency from 'webpack/lib/Dependency';
 
 class ContainerEntryDependency extends Dependency {
   public name: string;

--- a/packages/enhanced/src/lib/container/ContainerEntryModule.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryModule.ts
@@ -4,19 +4,14 @@
 */
 
 'use strict';
-//@ts-ignore
-import AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
-//@ts-ignore
-import Dependency = require('webpack/lib/Dependency');
-//@ts-ignore
-import Template = require('webpack/lib/Template');
-//@ts-ignore
-import Module = require('webpack/lib/Module');
+import AsyncDependenciesBlock from 'webpack/lib/AsyncDependenciesBlock';
+import Dependency from 'webpack/lib/Dependency';
+import Template from 'webpack/lib/Template';
+import Module from 'webpack/lib/Module';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 import { OriginalSource, RawSource } from 'webpack-sources';
 import { JAVASCRIPT_MODULE_TYPE_DYNAMIC } from 'webpack/lib/ModuleTypeConstants';
 import ContainerExposedDependency from './ContainerExposedDependency';
-//@ts-ignore
 import StaticExportsDependency = require('webpack/lib/dependencies/StaticExportsDependency');
 import type Compilation from 'webpack/lib/Compilation';
 import type {
@@ -30,8 +25,7 @@ import type {
   ResolverWithOptions,
 } from 'webpack/lib/Module';
 import type WebpackError from 'webpack/lib/WebpackError';
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 const SOURCE_TYPES = new Set(['javascript']);
 

--- a/packages/enhanced/src/lib/container/ContainerEntryModule.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryModule.ts
@@ -12,7 +12,7 @@ import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 import { OriginalSource, RawSource } from 'webpack-sources';
 import { JAVASCRIPT_MODULE_TYPE_DYNAMIC } from 'webpack/lib/ModuleTypeConstants';
 import ContainerExposedDependency from './ContainerExposedDependency';
-import StaticExportsDependency = require('webpack/lib/dependencies/StaticExportsDependency');
+import StaticExportsDependency from 'webpack/lib/dependencies/StaticExportsDependency';
 import type Compilation from 'webpack/lib/Compilation';
 import type {
   LibIdentOptions,

--- a/packages/enhanced/src/lib/container/ContainerEntryModuleFactory.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryModuleFactory.ts
@@ -7,8 +7,7 @@
 
 import ContainerEntryModule from './ContainerEntryModule';
 import ContainerEntryDependency from './ContainerEntryDependency';
-//@ts-ignore
-import ModuleFactory = require('webpack/lib/ModuleFactory');
+import ModuleFactory from 'webpack/lib/ModuleFactory';
 import type {
   ModuleFactoryCreateData,
   ModuleFactoryResult,

--- a/packages/enhanced/src/lib/container/ContainerExposedDependency.ts
+++ b/packages/enhanced/src/lib/container/ContainerExposedDependency.ts
@@ -7,10 +7,8 @@ import type {
   ObjectDeserializerContext,
   ObjectSerializerContext,
 } from 'webpack/lib/dependencies/ModuleDependency';
-//@ts-ignore
-import ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import ModuleDependency from 'webpack/lib/dependencies/ModuleDependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class ContainerExposedDependency extends ModuleDependency {
   exposedName: string;

--- a/packages/enhanced/src/lib/container/ContainerPlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerPlugin.ts
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy, Marais Rossouw @maraisr
 */
 //@ts-ignore
-import createSchemaValidation = require('webpack/lib/util/create-schema-validation');
+import createSchemaValidation from 'webpack/lib/util/create-schema-validation';
 import ContainerEntryDependency from './ContainerEntryDependency';
 import ContainerEntryModuleFactory from './ContainerEntryModuleFactory';
 import ContainerExposedDependency from './ContainerExposedDependency';

--- a/packages/enhanced/src/lib/container/ContainerReferencePlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerReferencePlugin.ts
@@ -5,8 +5,7 @@
 
 import type Compiler from 'webpack/lib/Compiler';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
-//@ts-ignore
-import createSchemaValidation = require('webpack/lib/util/create-schema-validation');
+import createSchemaValidation from 'webpack/lib/util/create-schema-validation';
 import FallbackDependency from './FallbackDependency';
 import FallbackItemDependency from './FallbackItemDependency';
 import FallbackModuleFactory from './FallbackModuleFactory';
@@ -14,13 +13,10 @@ import RemoteModule from './RemoteModule';
 import RemoteRuntimeModule from './RemoteRuntimeModule';
 import RemoteToExternalDependency from './RemoteToExternalDependency';
 import { parseOptions } from './options';
-//@ts-ignore
-import ExternalsPlugin = require('webpack/lib/ExternalsPlugin');
-
+import ExternalsPlugin from 'webpack/lib/ExternalsPlugin';
 import type Compilation from 'webpack/lib/Compilation';
 import type { ResolveData } from 'webpack/lib/NormalModuleFactory';
-//@ts-ignore
-import NormalModuleFactory = require('webpack/lib/NormalModuleFactory');
+import NormalModuleFactory from 'webpack/lib/NormalModuleFactory';
 import {
   ExternalsType,
   ContainerReferencePluginOptions,

--- a/packages/enhanced/src/lib/container/FallbackDependency.ts
+++ b/packages/enhanced/src/lib/container/FallbackDependency.ts
@@ -9,13 +9,8 @@ import type {
   ObjectDeserializerContext,
   ObjectSerializerContext,
 } from 'webpack/lib/Dependency';
-//@ts-ignore
-import Dependency = require('webpack/lib/Dependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
-
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
+import Dependency from 'webpack/lib/Dependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class FallbackDependency extends Dependency {
   requests: string[];

--- a/packages/enhanced/src/lib/container/FallbackItemDependency.ts
+++ b/packages/enhanced/src/lib/container/FallbackItemDependency.ts
@@ -2,10 +2,8 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy
 */
-//@ts-ignore
-import ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import ModuleDependency from 'webpack/lib/dependencies/ModuleDependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class FallbackItemDependency extends ModuleDependency {
   /**

--- a/packages/enhanced/src/lib/container/FallbackModule.ts
+++ b/packages/enhanced/src/lib/container/FallbackModule.ts
@@ -20,35 +20,14 @@ import type {
   ObjectDeserializerContext,
   ObjectSerializerContext,
 } from 'webpack/lib/Module';
-//@ts-ignore
-import Module = require('webpack/lib/Module');
+import Module from 'webpack/lib/Module';
 import type ChunkGraph from 'webpack/lib/ChunkGraph';
 import Chunk from 'webpack/lib/Chunk';
 import { WEBPACK_MODULE_TYPE_FALLBACK } from 'webpack/lib/ModuleTypeConstants';
-//@ts-ignore
-import RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
-//@ts-ignore
-import Template = require('webpack/lib/Template');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
+import Template from 'webpack/lib/Template';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 import FallbackItemDependency from './FallbackItemDependency';
-
-/** @typedef {import("webpack/lib/webpack/lib/declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
-/** @typedef {import("webpack/lib/Chunk")} Chunk */
-/** @typedef {import("webpack/lib/ChunkGraph")} ChunkGraph */
-/** @typedef {import("webpack/lib/ChunkGroup")} ChunkGroup */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
-/** @typedef {import("webpack/lib/Module").CodeGenerationContext} CodeGenerationContext */
-/** @typedef {import("webpack/lib/Module").CodeGenerationResult} CodeGenerationResult */
-/** @typedef {import("webpack/lib/Module").LibIdentOptions} LibIdentOptions */
-/** @typedef {import("webpack/lib/Module").NeedBuildContext} NeedBuildContext */
-/** @typedef {import("webpack/lib/RequestShortener")} RequestShortener */
-/** @typedef {import("webpack/lib/ResolverFactory").ResolverWithOptions} ResolverWithOptions */
-/** @typedef {import("webpack/lib/WebpackError")} WebpackError */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
-/** @typedef {import("webpack/lib/util/Hash")} Hash */
-/** @typedef {import("webpack/lib/util/fs").InputFileSystem} InputFileSystem */
 
 const TYPES = new Set(['javascript']);
 const RUNTIME_REQUIREMENTS = new Set([RuntimeGlobals.module]);

--- a/packages/enhanced/src/lib/container/FallbackModuleFactory.ts
+++ b/packages/enhanced/src/lib/container/FallbackModuleFactory.ts
@@ -8,14 +8,9 @@ import {
   ModuleFactoryCreateData,
   ModuleFactoryResult,
 } from 'webpack/lib/ModuleFactory';
-//@ts-ignore
-import ModuleFactory = require('webpack/lib/ModuleFactory');
+import ModuleFactory from 'webpack/lib/ModuleFactory';
 import FallbackModule from './FallbackModule';
 import FallbackDependency from './FallbackDependency';
-
-/** @typedef {import("webpack/lib/ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
-/** @typedef {import("webpack/lib/ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
-/** @typedef {import("./FallbackDependency")} FallbackDependency */
 
 export default class FallbackModuleFactory extends ModuleFactory {
   /**

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -6,19 +6,12 @@
 'use strict';
 
 import type Compiler from 'webpack/lib/Compiler';
-//@ts-ignore
-import isValidExternalsType = require('webpack/schemas/plugins/container/ExternalsType.check.js');
+import isValidExternalsType from 'webpack/schemas/plugins/container/ExternalsType.check.js';
 import type { ModuleFederationPluginOptions } from './ModuleFederationPluginTypes';
 import SharePlugin from '../sharing/SharePlugin';
-//@ts-ignore
-import createSchemaValidation = require('webpack/lib/util/create-schema-validation');
+import createSchemaValidation from 'webpack/lib/util/create-schema-validation';
 import ContainerPlugin from './ContainerPlugin';
 import ContainerReferencePlugin from './ContainerReferencePlugin';
-
-/** @typedef {import("./ModuleFederationPluginTypes").ExternalsType} ExternalsType */
-/** @typedef {import("./ModuleFederationPluginTypes").ModuleFederationPluginOptions} ModuleFederationPluginOptions */
-/** @typedef {import("./ModuleFederationPluginTypes").Shared} Shared */
-/** @typedef {import("webpack/lib/Compiler")} Compiler */
 
 const validate = createSchemaValidation(
   //eslint-disable-next-line

--- a/packages/enhanced/src/lib/container/RemoteModule.ts
+++ b/packages/enhanced/src/lib/container/RemoteModule.ts
@@ -11,12 +11,9 @@ import type {
   NeedBuildContext,
   WebpackError,
 } from 'webpack/lib/Module';
-//@ts-ignore
-import Module = require('webpack/lib/Module');
-//@ts-ignore
-import RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import Module from 'webpack/lib/Module';
+import RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 import FallbackDependency from './FallbackDependency';
 import RemoteToExternalDependency from './RemoteToExternalDependency';
 import type Compilation from 'webpack/lib/Compilation';

--- a/packages/enhanced/src/lib/container/RemoteRuntimeModule.ts
+++ b/packages/enhanced/src/lib/container/RemoteRuntimeModule.ts
@@ -2,17 +2,11 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy
 */
-//@ts-ignore
-import RuntimeGlobals = require('webpack/lib/RuntimeGlobals');
+import RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 import type Compilation from 'webpack/lib/Compilation';
 import RemoteModule from './RemoteModule';
-//@ts-ignore
-import RuntimeModule = require('webpack/lib/RuntimeModule');
-//@ts-ignore
-import Template = require('webpack/lib/Template');
-
-/** @typedef {import("webpack/lib/Chunk")} Chunk */
-/** @typedef {import("./RemoteModule")} RemoteModule */
+import RuntimeModule from 'webpack/lib/RuntimeModule';
+import Template from 'webpack/lib/Template';
 
 class RemoteRuntimeModule extends RuntimeModule {
   constructor() {

--- a/packages/enhanced/src/lib/container/RemoteToExternalDependency.ts
+++ b/packages/enhanced/src/lib/container/RemoteToExternalDependency.ts
@@ -4,10 +4,9 @@
 */
 
 'use strict';
-//@ts-ignore
-import ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+
+import ModuleDependency from 'webpack/lib/dependencies/ModuleDependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class RemoteToExternalDependency extends ModuleDependency {
   /**

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedFallbackDependency.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedFallbackDependency.ts
@@ -4,10 +4,9 @@
 */
 
 'use strict';
-//@ts-ignore
-import ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+
+import ModuleDependency from 'webpack/lib/dependencies/ModuleDependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class ConsumeSharedFallbackDependency extends ModuleDependency {
   /**

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
@@ -7,7 +7,7 @@
 
 import { RawSource } from 'webpack-sources';
 //@ts-ignore
-import AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
+import AsyncDependenciesBlock from 'webpack/lib/AsyncDependenciesBlock';
 import type {
   WebpackOptions,
   Compilation,
@@ -25,7 +25,7 @@ import type {
   InputFileSystem,
 } from 'webpack/lib/Module';
 //@ts-ignore
-import Module = require('webpack/lib/Module');
+import Module from 'webpack/lib/Module';
 import { WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE } from 'webpack/lib/ModuleTypeConstants';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 //@ts-ignore
@@ -73,24 +73,6 @@ export type ConsumeOptions = {
    */
   eager: boolean;
 };
-
-/** @typedef {import("webpack/declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
-/** @typedef {import("webpack/lib/ChunkGraph")} ChunkGraph */
-/** @typedef {import("webpack/lib/ChunkGroup")} ChunkGroup */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
-/** @typedef {import("webpack/lib/Dependency").UpdateHashContext} UpdateHashContext */
-/** @typedef {import("webpack/lib/Module").CodeGenerationContext} CodeGenerationContext */
-/** @typedef {import("webpack/lib/Module").CodeGenerationResult} CodeGenerationResult */
-/** @typedef {import("webpack/lib/Module").LibIdentOptions} LibIdentOptions */
-/** @typedef {import("webpack/lib/Module").NeedBuildContext} NeedBuildContext */
-/** @typedef {import("webpack/lib/RequestShortener")} RequestShortener */
-/** @typedef {import("webpack/lib/ResolverFactory").ResolverWithOptions} ResolverWithOptions */
-/** @typedef {import("webpack/lib/WebpackError")} WebpackError */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
-/** @typedef {import("webpack/lib/util/Hash")} Hash */
-/** @typedef {import("webpack/lib/util/fs").InputFileSystem} InputFileSystem */
-/** @typedef {import("webpack/lib/util/semver").SemVerRange} SemVerRange */
 
 /**
  * @typedef {Object} ConsumeOptions

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedModule.ts
@@ -29,7 +29,7 @@ import Module from 'webpack/lib/Module';
 import { WEBPACK_MODULE_TYPE_CONSUME_SHARED_MODULE } from 'webpack/lib/ModuleTypeConstants';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 //@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 import { rangeToString, stringifyHoley } from 'webpack/lib/util/semver';
 import ConsumeSharedFallbackDependency from './ConsumeSharedFallbackDependency';
 export type ConsumeOptions = {

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
@@ -21,23 +21,17 @@ import ConsumeSharedModule from './ConsumeSharedModule';
 import ConsumeSharedRuntimeModule from './ConsumeSharedRuntimeModule';
 import ProvideForSharedDependency from './ProvideForSharedDependency';
 //@ts-ignore
-import ModuleNotFoundError = require('webpack/lib/ModuleNotFoundError');
+import ModuleNotFoundError from 'webpack/lib/ModuleNotFoundError';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
 //@ts-ignore
-import WebpackError = require('webpack/lib/WebpackError');
+import WebpackError from 'webpack/lib/WebpackError';
 //@ts-ignore
-import Compiler = require('webpack/lib/Compiler');
+import Compiler from 'webpack/lib/Compiler';
 //@ts-ignore
-import LazySet = require('webpack/lib/util/LazySet');
+import LazySet from 'webpack/lib/util/LazySet';
 //@ts-ignore
-import createSchemaValidation = require('webpack/lib/util/create-schema-validation');
+import createSchemaValidation from 'webpack/lib/util/create-schema-validation';
 import { SemVerRange } from 'webpack/lib/util/semver';
-
-/** @typedef {import("../../declarations/plugins/sharing/ConsumeSharedPlugin").ConsumeSharedPluginOptions} ConsumeSharedPluginOptions */
-/** @typedef {import("../../declarations/plugins/sharing/ConsumeSharedPlugin").ConsumesConfig} ConsumesConfig */
-/** @typedef {import("webpack/lib/Compiler")} Compiler */
-/** @typedef {import("webpack/lib/ResolverFactory").ResolveOptionsWithDependencyType} ResolveOptionsWithDependencyType */
-/** @typedef {import("./ConsumeSharedModule").ConsumeOptions} ConsumeOptions */
 
 const validate = createSchemaValidation(
   //eslint-disable-next-line

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedRuntimeModule.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedRuntimeModule.ts
@@ -4,30 +4,20 @@
 */
 
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
-//@ts-ignore
-import Template = require('webpack/lib/Template');
+import Template from 'webpack/lib/Template';
 import {
   parseVersionRuntimeCode,
   versionLtRuntimeCode,
   rangeToStringRuntimeCode,
   satisfyRuntimeCode,
 } from 'webpack/lib/util/semver';
-//@ts-ignore
-import RuntimeModule = require('webpack/lib/RuntimeModule');
-//@ts-ignore
-import Module = require('webpack/lib/Module');
+import RuntimeModule from 'webpack/lib/RuntimeModule';
+import Module from 'webpack/lib/Module';
 import ConsumeSharedModule from './ConsumeSharedModule';
 import type ChunkGraph from 'webpack/lib/ChunkGraph';
 import type Compilation from 'webpack/lib/Compilation';
 import type Chunk from 'webpack/lib/Chunk';
 import { Source } from 'webpack-sources';
-
-/** @typedef {import("webpack-sources").Source} Source */
-/** @typedef {import("webpack/lib/Chunk")} Chunk */
-/** @typedef {import("webpack/lib/ChunkGraph")} ChunkGraph */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
-/** @typedef {import("webpack/lib/Module")} Module */
-/** @typedef {import("./ConsumeSharedModule")} ConsumeSharedModule */
 
 class ConsumeSharedRuntimeModule extends RuntimeModule {
   private _runtimeRequirements: ReadonlySet<string>;
@@ -44,10 +34,8 @@ class ConsumeSharedRuntimeModule extends RuntimeModule {
    * @returns {string | null} runtime code
    */
   override generate(): string | null {
-    //@ts-ignore
-    const compilation: Compilation = this.compilation;
-    //@ts-ignore
-    const chunkGraph: ChunkGraph = this.chunkGraph;
+    const compilation: Compilation = this.compilation!;
+    const chunkGraph: ChunkGraph = this.chunkGraph!;
     const { runtimeTemplate, codeGenerationResults } = compilation;
     const chunkToModuleMapping: Record<string, any> = {};
     const moduleIdToSourceMapping: Map<string | number, Source> = new Map();

--- a/packages/enhanced/src/lib/sharing/ProvideForSharedDependency.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideForSharedDependency.ts
@@ -2,10 +2,9 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy
 */
-//@ts-ignore
-import ModuleDependency = require('webpack/lib/dependencies/ModuleDependency');
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+
+import ModuleDependency from 'webpack/lib/dependencies/ModuleDependency';
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 
 class ProvideForSharedDependency extends ModuleDependency {
   /**

--- a/packages/enhanced/src/lib/sharing/ProvideSharedDependency.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedDependency.ts
@@ -2,16 +2,14 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra, Zackary Jackson @ScriptedAlchemy
 */
-//@ts-ignore
-import makeSerializable = require('webpack/lib/util/makeSerializable');
-//@ts-ignore
-import Dependency = require('webpack/lib/Dependency');
+
+import makeSerializable from 'webpack/lib/util/makeSerializable';
+import Dependency from 'webpack/lib/Dependency';
 import {
   ObjectDeserializerContext,
   ObjectSerializerContext,
 } from '../../declarations/plugins/container/Dependency';
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
+
 class ProvideSharedDependency extends Dependency {
   shareScope: string;
   name: string;

--- a/packages/enhanced/src/lib/sharing/ProvideSharedModule.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedModule.ts
@@ -6,7 +6,7 @@
 import AsyncDependenciesBlock from 'webpack/lib/AsyncDependenciesBlock';
 import Module from 'webpack/lib/Module';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
-import makeSerializable = require('webpack/lib/util/makeSerializable');
+import makeSerializable from 'webpack/lib/util/makeSerializable';
 import type Compilation from 'webpack/lib/Compilation';
 import WebpackError from 'webpack/lib/WebpackError';
 import { WEBPACK_MODULE_TYPE_PROVIDE } from 'webpack/lib/ModuleTypeConstants';

--- a/packages/enhanced/src/lib/sharing/ProvideSharedModule.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedModule.ts
@@ -2,16 +2,13 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
 */
-//@ts-ignore
-import AsyncDependenciesBlock = require('webpack/lib/AsyncDependenciesBlock');
-//@ts-ignore
-import Module = require('webpack/lib/Module');
+
+import AsyncDependenciesBlock from 'webpack/lib/AsyncDependenciesBlock';
+import Module from 'webpack/lib/Module';
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
-//@ts-ignore
 import makeSerializable = require('webpack/lib/util/makeSerializable');
 import type Compilation from 'webpack/lib/Compilation';
-//@ts-ignore
-import WebpackError = require('webpack/lib/WebpackError');
+import WebpackError from 'webpack/lib/WebpackError';
 import { WEBPACK_MODULE_TYPE_PROVIDE } from 'webpack/lib/ModuleTypeConstants';
 import type {
   CodeGenerationContext,
@@ -26,23 +23,6 @@ import type {
 import { InputFileSystem } from 'webpack/lib/util/fs';
 import ProvideForSharedDependency from './ProvideForSharedDependency';
 import { WebpackOptionsNormalized as WebpackOptions } from 'webpack/declarations/WebpackOptions';
-
-/** @typedef {import("webpack/declarations/WebpackOptions").WebpackOptionsNormalized} WebpackOptions */
-/** @typedef {import("webpack/lib/Chunk")} Chunk */
-/** @typedef {import("webpack/lib/ChunkGraph")} ChunkGraph */
-/** @typedef {import("webpack/lib/ChunkGroup")} ChunkGroup */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
-/** @typedef {import("webpack/lib/Module").CodeGenerationContext} CodeGenerationContext */
-/** @typedef {import("webpack/lib/Module").CodeGenerationResult} CodeGenerationResult */
-/** @typedef {import("webpack/lib/Module").LibIdentOptions} LibIdentOptions */
-/** @typedef {import("webpack/lib/Module").NeedBuildContext} NeedBuildContext */
-/** @typedef {import("webpack/lib/RequestShortener")} RequestShortener */
-/** @typedef {import("webpack/lib/ResolverFactory").ResolverWithOptions} ResolverWithOptions */
-/** @typedef {import("webpack/lib/WebpackError")} WebpackError */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectDeserializerContext} ObjectDeserializerContext */
-/** @typedef {import("webpack/lib/serialization/ObjectMiddleware").ObjectSerializerContext} ObjectSerializerContext */
-/** @typedef {import("webpack/lib/util/Hash")} Hash */
-/** @typedef {import("webpack/lib/util/fs").InputFileSystem} InputFileSystem */
 
 const TYPES = new Set(['share-init']);
 

--- a/packages/enhanced/src/lib/sharing/ProvideSharedModuleFactory.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedModuleFactory.ts
@@ -3,7 +3,7 @@
 	Author Tobias Koppers @sokra and Zackary Jackson @ScriptedAlchemy
 */
 //@ts-ignore
-import ModuleFactory = require('webpack/lib/ModuleFactory');
+import ModuleFactory from 'webpack/lib/ModuleFactory';
 import ProvideSharedModule from './ProvideSharedModule';
 import type {
   ModuleFactoryCreateData,
@@ -11,9 +11,6 @@ import type {
 } from 'webpack/lib/ModuleFactory';
 import ProvideSharedDependency from './ProvideSharedDependency';
 
-/** @typedef {import("webpack/lib/ModuleFactory").ModuleFactoryCreateData} ModuleFactoryCreateData */
-/** @typedef {import("webpack/lib/ModuleFactory").ModuleFactoryResult} ModuleFactoryResult */
-/** @typedef {import("./ProvideSharedDependency")} ProvideSharedDependency */
 class ProvideSharedModuleFactory extends ModuleFactory {
   /**
    * @param {ModuleFactoryCreateData} data data object

--- a/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ProvideSharedPlugin.ts
@@ -6,10 +6,8 @@
 'use strict';
 
 import { parseOptions } from '../container/options';
-//@ts-ignore
-import createSchemaValidation = require('webpack/lib/util/create-schema-validation');
-//@ts-ignore
-import WebpackError = require('webpack/lib/WebpackError');
+import createSchemaValidation from 'webpack/lib/util/create-schema-validation';
+import WebpackError from 'webpack/lib/WebpackError';
 import ProvideForSharedDependency from './ProvideForSharedDependency';
 import ProvideSharedDependency from './ProvideSharedDependency';
 import ProvideSharedModuleFactory from './ProvideSharedModuleFactory';
@@ -30,10 +28,6 @@ export type ResolvedProvideMap = Map<
     version: string | undefined | false;
   }
 >;
-
-/** @typedef {import("./ProvideSharedPlugin").ProvideSharedPluginOptions} ProvideSharedPluginOptions */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
-/** @typedef {import("webpack/lib/Compiler")} Compiler */
 
 const validate = createSchemaValidation(
   //eslint-disable-next-line

--- a/packages/enhanced/src/lib/sharing/SharePlugin.ts
+++ b/packages/enhanced/src/lib/sharing/SharePlugin.ts
@@ -17,14 +17,6 @@ import type { ConsumesConfig } from '../../declarations/plugins/sharing/ConsumeS
 import type Compiler from 'webpack/lib/Compiler';
 import type { ProvidesConfig } from '../../declarations/plugins/sharing/ProvideSharedPlugin';
 
-/** @typedef {import("../sharing/ConsumeSharedPlugin").ConsumeSharedPluginOptions} ConsumeSharedPluginOptions */
-/** @typedef {import("../sharing/ConsumeSharedPlugin").ConsumesConfig} ConsumesConfig */
-/** @typedef {import("../sharing/ProvideSharedPlugin").ProvideSharedPluginOptions} ProvideSharedPluginOptions */
-/** @typedef {import("../sharing/ProvideSharedPlugin").ProvidesConfig} ProvidesConfig */
-/** @typedef {import("../sharing/SharePlugin").SharePluginOptions} SharePluginOptions */
-/** @typedef {import("../sharing/SharePlugin").SharedConfig} SharedConfig */
-/** @typedef {import("webpack/lib/Compiler")} Compiler */
-
 class SharePlugin {
   private _shareScope: string;
   private _consumes: Record<string, ConsumesConfig>[];

--- a/packages/enhanced/src/lib/sharing/ShareRuntimeModule.ts
+++ b/packages/enhanced/src/lib/sharing/ShareRuntimeModule.ts
@@ -6,18 +6,14 @@
 'use strict';
 
 import * as RuntimeGlobals from 'webpack/lib/RuntimeGlobals';
-import RuntimeModule = require('webpack/lib/RuntimeModule');
-import Template = require('webpack/lib/Template');
+import RuntimeModule from 'webpack/lib/RuntimeModule';
+import Template from 'webpack/lib/Template';
 import Compilation from 'webpack/lib/Compilation';
 import ChunkGraph from 'webpack/lib/ChunkGraph';
 import {
   compareModulesByIdentifier,
   compareStrings,
 } from 'webpack/lib/util/comparators';
-
-/** @typedef {import("webpack/lib/Chunk")} Chunk */
-/** @typedef {import("webpack/lib/ChunkGraph")} ChunkGraph */
-/** @typedef {import("webpack/lib/Compilation")} Compilation */
 
 class ShareRuntimeModule extends RuntimeModule {
   constructor() {

--- a/packages/enhanced/src/lib/sharing/resolveMatchedConfigs.ts
+++ b/packages/enhanced/src/lib/sharing/resolveMatchedConfigs.ts
@@ -4,10 +4,8 @@
 */
 import type Compilation from 'webpack/lib/Compilation';
 import type { ResolveOptionsWithDependencyType } from 'webpack/lib/ResolverFactory';
-//@ts-ignore
-import ModuleNotFoundError = require('webpack/lib/ModuleNotFoundError');
-//@ts-ignore
-import LazySet = require('webpack/lib/util/LazySet');
+import ModuleNotFoundError from 'webpack/lib/ModuleNotFoundError';
+import LazySet from 'webpack/lib/util/LazySet';
 
 interface MatchedConfigs<T> {
   resolved: Map<string, T>;

--- a/packages/enhanced/tsconfig.json
+++ b/packages/enhanced/tsconfig.json
@@ -1,18 +1,19 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "declaration": true,
-    "module": "commonjs",
+    "module": "NodeNext",
     "allowJs": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
+    "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true
   },


### PR DESCRIPTION
@ScriptedAlchemy - it turns out the import require syntax can be worked around if we use the swc interop helper:

https://swc.rs/docs/configuration/modules#nointerop

We can technically just remove noInterop from .swcrc and it'll work but I made them explicit for now. You can see the difference in the compiled code where they wrap require statements in their wrapper. But this removes the need to import = require().

Tested with start:node and start:next