### PR TITLE
fix: move cache file hashing to next-mf

### DIFF
--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/apply-server-plugins.ts
@@ -21,6 +21,14 @@ export function applyServerPlugins(
 ): void {
   // Import the StreamingTargetPlugin from @module-federation/node
   const { StreamingTargetPlugin } = require('@module-federation/node');
+  const chunkFileName = compiler.options?.output?.chunkFilename;
+  const uniqueName = compiler?.options?.output?.uniqueName || options.name;
+  if (typeof chunkFileName === 'string' &&
+    uniqueName &&
+    !chunkFileName.includes(uniqueName)) {
+    const suffix = `-[chunkhash].js`;
+    compiler.options.output.chunkFilename = chunkFileName.replace('.js', suffix);
+  }
   new ModuleInfoRuntimePlugin().apply(compiler);
   // Apply the DelegatesModulePlugin to the compiler
   new DelegatesModulePlugin({


### PR DESCRIPTION
Resolves issues seen in examples repo, where chunks are the same. 

Next no longer uses the main NodeFederationPlugin instance directly. Instead, federation is directly applied via the underlaying plugins