### PR TITLE
fix: filter empty cache files

### DIFF
--- a/packages/typescript/src/plugins/FederatedTypesPlugin.ts
+++ b/packages/typescript/src/plugins/FederatedTypesPlugin.ts
@@ -319,7 +319,7 @@ export class FederatedTypesPlugin {
 
         if (filesToCacheBust.length > 0) {
           await Promise.all(
-            filesToCacheBust.map((file) => {
+            filesToCacheBust.filter(Boolean).map((file) => {
               const url = new URL(
                 path.join(origin, typescriptFolderName, file),
               ).toString();


### PR DESCRIPTION
After installing @module-federation/typescript, I was getting an error that file was not found. In my case this happened because one of the cached files marked for busting was an empty string. This change fixes that by filtering out empty strings for files paths