### PR TITLE
Fix: Typescript - make SWC helpers embedded

### DIFF
--- a/packages/typescript/.swcrc
+++ b/packages/typescript/.swcrc
@@ -11,7 +11,7 @@
       "legacyDecorator": true
     },
     "keepClassNames": true,
-    "externalHelpers": true,
+    "externalHelpers": false,
     "loose": true
   },
   "module": {


### PR DESCRIPTION
This fixes scenarios where the consuming project does not have @swc/helpers installed. By leaving them external it expects to find them in node_modules, but embedding them at build time is likely the best option.