### PR TITLE
Docs/creating new package instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,3 +119,14 @@ To trigger releases manually:
 
 This ensures a consistent and automated release cycle across different channels, in line with modern CI/CD practices.
 
+### Creating new packages/projects
+
+To create a new package/project you can use any Nx generator you like/need, just make sure to add the `package` tag to the project and include the `release` target in the `package.json` file.
+
+The nx-semantic-release plugin does NOT know when the package was created, so we need to manually create the first tag for the package, also keep in mind that the first version of the package should be `1.0.0` and not `0.0.0`, so to create the first tag for the package you can run:
+
+```sh
+git tag -a <PROJECT_NAME>-<VERSION>
+```
+
+Note that this format is important for the nx-semantic-release plugin understand the version of the package, you can check the used format in this project on the `tagFormat` option in the `nxrelease.config.js` file.


### PR DESCRIPTION
This PR add instructions about how to create a new package/project, it became important after we got release issues after creating the sdk package.

A tag named sdk-1.0.0 was manually created and force pushed pointing to the commit 611755cb6dcd5c02fbb392d190d43f3bcb49e238, in which the package was introduced.

The tag sdk-1.0.0-canary.1 was force changed to 611755cb6dcd5c02fbb392d190d43f3bcb49e238 too

A release action for the package was [triggered here](https://github.com/module-federation/universe/actions/runs/7094754206) 

As the project received commit messages marked with the `fix` release type, the package was bumped to version [1.1.0-canary.1](https://github.com/module-federation/universe/blob/canary/packages/sdk/CHANGELOG.md#110-canary1-2023-12-05)

More information about contributing changes is on the CONTRIBUTING.md
Resources:
[New projects analyze all previous commits](https://github.com/TheUnderScorer/nx-semantic-release/issues/90)
[Not detecting existing release](https://github.com/semantic-release/semantic-release/issues/1121#top)