### PR TITLE
fix: prevent react refresh on internals

### DIFF
--- a/packages/nextjs-mf/src/loaders/helpers.ts
+++ b/packages/nextjs-mf/src/loaders/helpers.ts
@@ -52,6 +52,10 @@ export function hasLoader(rule: RuleSetRuleUnion, loaderName: string) {
             loader.loader.includes(`/${loaderName}/`))
         ) {
           return true;
+        } else if (typeof loader === 'string') {
+          if (loader === loaderName || loader.includes(`/${loaderName}/`)) {
+            return true;
+          }
         }
       }
     }

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/next-fragments.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/next-fragments.ts
@@ -118,5 +118,18 @@ export const applyPathFixes = (compiler: Compiler, options: any) => {
         loader: require.resolve('../../loaders/fixUrlLoader'),
       });
     }
+    //@ts-ignore
+    if (rule?.oneOf) {
+      //@ts-ignore
+      rule.oneOf.forEach((oneOfRule) => {
+        if (hasLoader(oneOfRule, 'react-refresh-utils')) {
+          oneOfRule.exclude = [
+            oneOfRule.exclude,
+            /enhanced\/src/,
+            /nextjs-mf\/src/,
+          ];
+        }
+      });
+    }
   });
 };


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Prevent react loader from transforming internal packages
<!--- Describe your changes in detail -->
react loader will try to use import.meta in commonjs packages during transform.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
