### PR TITLE
feat(runtime): resolveShare runtime hooks

### DIFF
--- a/packages/runtime/src/core.md
+++ b/packages/runtime/src/core.md
@@ -82,7 +82,36 @@ initializeSharing(shareScopeName?: string): boolean | Promise<boolean>
 Initializes sharing sequences for shared scopes.
 
 ## Hooks
-`FederationHost` offers various lifecycle hooks for interacting at different stages of the module federation process.
+`FederationHost` offers various lifecycle hooks for interacting at different stages of the module federation process. These hooks include:
+
+- **`beforeInit`**: `SyncWaterfallHook<{ userOptions: UserOptions; options: Options; origin: FederationHost; shareInfo: ShareInfos; }>`
+  - Updates Federation Host configurations before the initialization process of remote containers.
+- **`init`**: `SyncHook<[{ options: Options; origin: FederationHost; }], void>`
+  - Called during the initialization of remote containers.
+- **`beforeRequest`**: `AsyncWaterfallHook<{ id: string; options: Options; origin: FederationHost; }>`
+  - Invoked before resolving a remote container, useful for injecting the container or updating something ahead of the lookup.
+- **`afterResolve`**: `AsyncWaterfallHook<LoadRemoteMatch>`
+  - Called after resolving a container, allowing redirection or modification of resolved information.
+- **`onLoad`**: `AsyncHook<[{ id: string; expose: string; pkgNameOrAlias: string; remote: Remote; options: ModuleOptions; origin: FederationHost; exposeModule: any; exposeModuleFactory: any; moduleInstance: Module; }], void>`
+  - Triggered once a federated module is loaded, allowing access and modification to the exports of the loaded file.
+- **`handlePreloadModule`**: `SyncHook<{ id: string; name: string; remoteSnapshot: ModuleInfo; preloadConfig: PreloadRemoteArgs; }, void>`
+  - Handles preloading logic for federated modules.
+- **`errorLoadRemote`**: `AsyncHook<[{ id: string; error: unknown; }], void>`
+  - Invoked if loading a federated module fails, enabling custom error handling.
+- **`beforeLoadShare`**: `AsyncWaterfallHook<{ pkgName: string; shareInfo?: Shared;
+
+ shared: Options['shared']; origin: FederationHost; }>`
+  - Called before attempting to load or negotiate shared modules between federated apps.
+- **`loadShare`**: `AsyncHook<[FederationHost, string, ShareInfos]>`
+  - Similar to `onLoad`, but for shared modules.
+- **`resolveShare`**: `SyncHook<[{ shareScopeMap: ShareScopeMap; scope: string; pkgName: string; version: string; GlobalFederation: Federation; resolver: () => Shared; }], void>`
+  - Allows manual resolution of shared module requests.
+- **`beforePreloadRemote`**: `AsyncHook<{ preloadOps: Array<PreloadRemoteArgs>; options: Options; origin: FederationHost; }>`
+  - Invoked before any preload logic is executed by the preload handler.
+- **`generatePreloadAssets`**: `AsyncHook<[{ origin: FederationHost; preloadOptions: PreloadOptions[number]; remote: Remote; remoteInfo: RemoteInfo; remoteSnapshot: ModuleInfo; globalSnapshot: GlobalModuleInfo; }], Promise<PreloadAssets>>`
+  - Called for generating preload assets based on configurations.
+- **`afterPreloadRemote`**: `AsyncHook<{ preloadOps: Array<PreloadRemoteArgs>; options: Options; origin: FederationHost; }>`
+  - Invoked after the remote modules are preloaded.
 
 ## Plugin System Integration
 `FederationHost` utilizes `PluginSystem` for extended capabilities and custom behavior integration, using `FederationRuntimePlugin`.

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -119,19 +119,14 @@ export class FederationHost {
       origin: FederationHost;
     }>('beforeLoadShare'),
     loadShare: new AsyncHook<[FederationHost, string, ShareInfos]>(),
-    resolveShare: new SyncHook<
-      [
-        {
-          shareScopeMap: ShareScopeMap;
-          scope: string;
-          pkgName: string;
-          version: string;
-          GlobalFederation: Federation;
-          resolver: () => Shared;
-        },
-      ],
-      void
-    >(),
+    resolveShare: new SyncWaterfallHook<{
+      shareScopeMap: ShareScopeMap;
+      scope: string;
+      pkgName: string;
+      version: string;
+      GlobalFederation: Federation;
+      resolver: () => Shared | undefined;
+    }>('resolveShare'),
     beforePreloadRemote: new AsyncHook<{
       preloadOps: Array<PreloadRemoteArgs>;
       options: Options;

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -39,7 +39,7 @@ import { generatePreloadAssetsPlugin } from './plugins/generate-preload-assets';
 import { snapshotPlugin } from './plugins/snapshot';
 import { isBrowserEnv } from './utils/env';
 import { getRemoteInfo } from './utils/load';
-import { Global } from './global';
+import { Global, Federation } from './global';
 import { DEFAULT_REMOTE_TYPE, DEFAULT_SCOPE } from './constant';
 import { SnapshotHandler } from './plugins/snapshot/SnapshotHandler';
 
@@ -119,6 +119,19 @@ export class FederationHost {
       origin: FederationHost;
     }>('beforeLoadShare'),
     loadShare: new AsyncHook<[FederationHost, string, ShareInfos]>(),
+    resolveShare: new SyncHook<
+      [
+        {
+          shareScopeMap: ShareScopeMap;
+          scope: string;
+          pkgName: string;
+          version: string;
+          GlobalFederation: Federation;
+          resolver: () => Shared;
+        },
+      ],
+      void
+    >(),
     beforePreloadRemote: new AsyncHook<{
       preloadOps: Array<PreloadRemoteArgs>;
       options: Options;
@@ -250,6 +263,7 @@ export class FederationHost {
       this.shareScopeMap,
       pkgName,
       shareInfoRes,
+      this.hooks.lifecycle.resolveShare,
     );
 
     const addUseIn = (shared: Shared): void => {
@@ -284,6 +298,7 @@ export class FederationHost {
           this.shareScopeMap,
           pkgName,
           shareInfoRes,
+          this.hooks.lifecycle.resolveShare,
         );
         if (gShared) {
           gShared.lib = factory;
@@ -314,6 +329,7 @@ export class FederationHost {
           this.shareScopeMap,
           pkgName,
           shareInfoRes,
+          this.hooks.lifecycle.resolveShare,
         );
         if (gShared) {
           gShared.lib = factory;
@@ -344,6 +360,7 @@ export class FederationHost {
       this.shareScopeMap,
       pkgName,
       shareInfo,
+      this.hooks.lifecycle.resolveShare,
     );
 
     if (registeredShared && typeof registeredShared.lib === 'function') {
@@ -594,10 +611,12 @@ export class FederationHost {
 
     const initRemoteModule = async (key: string): Promise<void> => {
       const { module } = await this._getRemoteModuleAndOptions(key);
-      const entry = await module.getEntry();
-      if (!module.inited) {
-        initFn(entry);
-        module.inited = true;
+      if (module.getEntry) {
+        const entry = await module.getEntry();
+        if (!module.inited) {
+          initFn(entry);
+          module.inited = true;
+        }
       }
     };
     Object.keys(this.options.shared).forEach((shareName) => {
@@ -702,6 +721,7 @@ export class FederationHost {
         this.shareScopeMap,
         sharedKey,
         sharedVal,
+        this.hooks.lifecycle.resolveShare,
       );
       if (!registeredShared && sharedVal && sharedVal.lib) {
         this.setShared({

--- a/packages/runtime/src/module/index.ts
+++ b/packages/runtime/src/module/index.ts
@@ -59,6 +59,10 @@ class Module {
       remoteEntryExports: this.remoteEntryExports,
       createScriptHook: (url: string) => {
         const res = this.loaderHook.lifecycle.createScript.emit({ url });
+        if (typeof document === 'undefined') {
+          //todo: needs real fix
+          return res as HTMLScriptElement;
+        }
         if (res instanceof HTMLScriptElement) {
           return res;
         }

--- a/packages/runtime/src/plugins/generate-preload-assets.ts
+++ b/packages/runtime/src/plugins/generate-preload-assets.ts
@@ -269,6 +269,7 @@ export function generatePreloadAssets(
         origin.shareScopeMap,
         shared.sharedName,
         shareInfo,
+        origin.hooks.lifecycle.resolveShare,
       );
       // If the global share does not exist, or the lib function does not exist, it means that the shared has not been loaded yet and can be preloaded.
 

--- a/packages/runtime/src/utils/load.ts
+++ b/packages/runtime/src/utils/load.ts
@@ -1,4 +1,8 @@
-import { composeKeyWithSeparator, loadScript } from '@module-federation/sdk';
+import {
+  composeKeyWithSeparator,
+  loadScript,
+  loadScriptNode,
+} from '@module-federation/sdk';
 import { assert } from '../utils/logger';
 import { getRemoteEntryExports, globalLoading } from '../global';
 import { Remote, RemoteEntryExports, RemoteInfo } from '../type';
@@ -46,6 +50,30 @@ export async function loadEntryScript({
 
   if (remoteEntryExports) {
     return remoteEntryExports;
+  }
+
+  if (typeof document === 'undefined') {
+    return loadScriptNode(entry, {
+      attrs: { name, globalName },
+      createScriptHook,
+    }).then(() => {
+      const { remoteEntryKey, entryExports } = getRemoteEntryExports(
+        name,
+        globalName,
+      );
+
+      assert(
+        entryExports,
+        `
+        Unable to use the ${name}'s '${entry}' URL with ${remoteEntryKey}'s globalName to get remoteEntry exports.
+        Possible reasons could be:\n
+        1. '${entry}' is not the correct URL, or the remoteEntry resource or name is incorrect.\n
+        2. ${remoteEntryKey} cannot be used to get remoteEntry exports in the window object.
+      `,
+      );
+
+      return entryExports;
+    });
   }
 
   return loadScript(entry, { attrs: {}, createScriptHook }).then(() => {

--- a/packages/runtime/src/utils/share.ts
+++ b/packages/runtime/src/utils/share.ts
@@ -151,6 +151,7 @@ export function getRegisteredShare(
   localShareScopeMap: ShareScopeMap,
   pkgName: string,
   shareInfo: ShareInfos[keyof ShareInfos],
+  resolveShareHook: any,
 ): Shared | void {
   if (!localShareScopeMap) {
     return;
@@ -164,55 +165,54 @@ export function getRegisteredShare(
       localShareScopeMap[sc][pkgName]
     ) {
       const { requiredVersion } = shareConfig;
-      // eslint-disable-next-line max-depth
-      if (shareConfig.singleton) {
-        const singletonVersion = getFindShareFunction(strategy)(
-          localShareScopeMap,
-          sc,
-          pkgName,
-        );
-        // eslint-disable-next-line max-depth
-        if (
-          typeof requiredVersion === 'string' &&
-          !satisfy(singletonVersion, requiredVersion)
-        ) {
-          warn(
-            `Version ${singletonVersion} from ${
-              singletonVersion &&
-              localShareScopeMap[sc][pkgName][singletonVersion].from
-            } of shared singleton module ${pkgName} does not satisfy the requirement of ${
-              shareInfo.from
-            } which needs ${requiredVersion})`,
-          );
-        }
-        return localShareScopeMap[sc][pkgName][singletonVersion];
-      } else {
-        const maxVersion = getFindShareFunction(strategy)(
-          localShareScopeMap,
-          sc,
-          pkgName,
-        );
+      const findShareFunction = getFindShareFunction(strategy);
+      const maxOrSingletonVersion = findShareFunction(
+        localShareScopeMap,
+        sc,
+        pkgName,
+      );
 
-        // eslint-disable-next-line max-depth
-        if (requiredVersion === false || requiredVersion === '*') {
-          return localShareScopeMap[sc][pkgName][maxVersion];
-        }
+      //@ts-ignore
+      const defaultResolver = () => {
+        if (shareConfig.singleton) {
+          if (
+            typeof requiredVersion === 'string' &&
+            !satisfy(maxOrSingletonVersion, requiredVersion)
+          ) {
+            warn(
+              `Version ${maxOrSingletonVersion} from ${
+                maxOrSingletonVersion &&
+                localShareScopeMap[sc][pkgName][maxOrSingletonVersion].from
+              } of shared singleton module ${pkgName} does not satisfy the requirement of ${
+                shareInfo.from
+              } which needs ${requiredVersion})`,
+            );
+          }
+          return localShareScopeMap[sc][pkgName][maxOrSingletonVersion];
+        } else {
+          if (requiredVersion === false || requiredVersion === '*') {
+            return localShareScopeMap[sc][pkgName][maxOrSingletonVersion];
+          }
 
-        // eslint-disable-next-line max-depth
-        if (satisfy(maxVersion, requiredVersion)) {
-          return localShareScopeMap[sc][pkgName][maxVersion];
-        }
-
-        // eslint-disable-next-line max-depth
-        for (const [versionKey, versionValue] of Object.entries(
-          localShareScopeMap[sc][pkgName],
-        )) {
-          // eslint-disable-next-line max-depth
-          if (satisfy(versionKey, requiredVersion)) {
-            return versionValue;
+          for (const [versionKey, versionValue] of Object.entries(
+            localShareScopeMap[sc][pkgName],
+          )) {
+            if (satisfy(versionKey, requiredVersion)) {
+              return versionValue;
+            }
           }
         }
-      }
+      };
+      const params = {
+        shareScopeMap: localShareScopeMap,
+        scope: sc,
+        pkgName,
+        version: maxOrSingletonVersion,
+        GlobalFederation: Global.__FEDERATION__,
+        resolver: defaultResolver,
+      };
+      const resolveShared = resolveShareHook.emit(params) || params;
+      return resolveShared.resolver();
     }
   }
 }

--- a/packages/runtime/src/utils/share.ts
+++ b/packages/runtime/src/utils/share.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SCOPE } from '../constant';
-import { Global } from '../global';
+import { Global, Federation } from '../global';
 import {
   GlobalShareScopeMap,
   Shared,
@@ -9,6 +9,7 @@ import {
 } from '../type';
 import { warn } from './logger';
 import { satisfy } from './semver';
+import { SyncWaterfallHook } from './hooks';
 
 export function formatShare(shareArgs: ShareArgs, from: string): Shared {
   let get: Shared['get'];
@@ -151,7 +152,14 @@ export function getRegisteredShare(
   localShareScopeMap: ShareScopeMap,
   pkgName: string,
   shareInfo: ShareInfos[keyof ShareInfos],
-  resolveShareHook: any,
+  resolveShare: SyncWaterfallHook<{
+    shareScopeMap: ShareScopeMap;
+    scope: string;
+    pkgName: string;
+    version: string;
+    GlobalFederation: Federation;
+    resolver: () => Shared | undefined;
+  }>,
 ): Shared | void {
   if (!localShareScopeMap) {
     return;
@@ -211,7 +219,7 @@ export function getRegisteredShare(
         GlobalFederation: Global.__FEDERATION__,
         resolver: defaultResolver,
       };
-      const resolveShared = resolveShareHook.emit(params) || params;
+      const resolveShared = resolveShare.emit(params) || params;
       return resolveShared.resolver();
     }
   }


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
- Features have been added to enhance the functionality of the FederationHost lifecycle hooks, the resolveShare hook in the FederationHost class, the generatePreloadAssets function, and the getRegisteredShare function. 
- A new function, loadScriptNode, has also been added to handle script loading when the document is undefined in node.js environments
- adds types for resolveShare hook

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
