### PR TITLE
fix: vitest not throw error while using @nx/vite:test directly

### DIFF
--- a/packages/runtime/project.json
+++ b/packages/runtime/project.json
@@ -59,16 +59,15 @@
       }
     },
     "test": {
-      "executor": "@nx/vite:test",
-      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "executor": "nx:run-commands",
       "options": {
-        "config": "packages/runtime/vitest.config.ts"
-      },
-      "configurations": {
-        "ci": {
-          "ci": true,
-          "codeCoverage": true
-        }
+        "parallel": false,
+        "commands": [
+          {
+            "command": "vitest run -c packages/runtime/vitest.config.ts",
+            "forwardAllArgs": false
+          }
+        ]
       }
     }
   },

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-
+import path from 'path';
 export default defineConfig({
   define: {
     __DEV__: true,
@@ -11,9 +11,9 @@ export default defineConfig({
   plugins: [nxViteTsPaths()],
   test: {
     environment: 'jsdom',
-    include: ['__tests__/*.spec.ts'],
+    include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
     globals: true,
-    setupFiles: ['./__tests__/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './__tests__/setup.ts')],
     testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Description

before(can not see error infos) :
![image](https://github.com/module-federation/universe/assets/41466093/813d5118-63c9-4359-8bf7-6a6942e33d12)
after:
![image](https://github.com/module-federation/universe/assets/41466093/537d4db5-bfc9-423d-aa35-929a98ca4d23)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
