### PR TITLE
Release v0.0.5

### DIFF
--- a/.changeset/stale-horses-bathe.md
+++ b/.changeset/stale-horses-bathe.md
@@ -1,5 +1,0 @@
----
-'@module-federation/sdk': patch
----
-
-chore: export sdk simpleJoinRemoteEntry function

--- a/.changeset/wet-dancers-raise.md
+++ b/.changeset/wet-dancers-raise.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-chore(runtime): support entry with query

--- a/packages/enhanced/.eslintrc.json
+++ b/packages/enhanced/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": ["../../.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": ["!**/*", "**/*.d.ts"],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [0.2.0-canary.5](https://github.com/module-federation/universe/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [5a79cb3]
+  - @module-federation/sdk@0.0.5
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [8.1.0-canary.7](https://github.com/module-federation/universe/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.1.1
+
+### Patch Changes
+
+- Updated dependencies [5a79cb3]
+  - @module-federation/sdk@0.0.5
+  - @module-federation/enhanced@0.0.5
+  - @module-federation/node@2.0.3
+
 ## 8.1.0
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [2.1.0-canary.6](https://github.com/module-federation/universe/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.0.3
+
+### Patch Changes
+
+- Updated dependencies [5a79cb3]
+  - @module-federation/sdk@0.0.5
+  - @module-federation/enhanced@0.0.5
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/runtime
 
+## 0.0.5
+
+### Patch Changes
+
+- 0dce151: chore(runtime): support entry with query
+- Updated dependencies [5a79cb3]
+  - @module-federation/sdk@0.0.5
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # [1.1.0-canary.1](https://github.com/module-federation/universe/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.0.5
+
+### Patch Changes
+
+- 5a79cb3: chore: export sdk simpleJoinRemoteEntry function
+
 ## 0.0.4
 
 ### Bug Fixes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [1.0.0-canary.3](https://github.com/module-federation/universe/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.0.5
+
+### Patch Changes
+
+- Updated dependencies [0dce151]
+  - @module-federation/runtime@0.0.5
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
## New Features 🎉 

* feat(runtime): support entry with query by @2heal1 in #1833 
* feat: export sdk simpleJoinRemoteEntry function by @2heal1 in #1858

## Bug Fixes 🐞

* fix: vitest not throw error while using @nx/vite:test directly by @2heal1 in #1855 

## Other Changes

* chore: Release v0.0.4 by @zhoushaw in #1811 
* chore: remove unused packages by @ScriptedAlchemy in #1825
* chore(deps): update dependency typedoc to v0.25.4 by @renovate in #1805 
* chore(deps): update dependency react-router-dom to v6.21.1 by @renovate in #1846 
* chore(deps): update dependency regenerator-runtime to v0.14.1 by @renovate in #1804 
* chore(deps): update dependency undici to v5.28.2 by @renovate in #1847 
* chore(deps): update dependency core-js to v3.34.0 by @renovate in #1845


Full Changelog: [v0.0.4...v0.0.5](https://github.com/module-federation/universe/compare/v0.0.4...v0.0.5)
