### PR TITLE
fix: rename usePlugins to prevent swc react-refresh from throwing errors when replacing variables

### DIFF
--- a/.changeset/honest-peas-dress.md
+++ b/.changeset/honest-peas-dress.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix: rename usePlugins to prevent swc react-refresh from throwing errors when replacing variables

--- a/packages/runtime/src/utils/hooks/pluginSystem.ts
+++ b/packages/runtime/src/utils/hooks/pluginSystem.ts
@@ -17,7 +17,7 @@ export class PluginSystem<T extends Record<string, any>> {
     this.lifecycleKeys = Object.keys(lifecycle);
   }
 
-  usePlugin(plugin: Plugin<T>): void {
+  applyPlugin(plugin: Plugin<T>): void {
     assert(isPlainObject(plugin), 'Plugin configuration is invalid.');
     // The plugin's name is mandatory and must be unique
     const pluginName = plugin.name;
@@ -67,7 +67,7 @@ export class PluginSystem<T extends Record<string, any>> {
         !this.registerPlugins[pluginName],
         `The plugin "${pluginName}" has a conflict and cannot be inherited.`,
       );
-      this.usePlugin(registerPlugins[pluginName]);
+      this.applyPlugin(registerPlugins[pluginName]);
     });
   }
 }

--- a/packages/runtime/src/utils/plugin.ts
+++ b/packages/runtime/src/utils/plugin.ts
@@ -24,7 +24,7 @@ export function registerPlugins(
   if (plugins && plugins.length > 0) {
     plugins.forEach((plugin) => {
       hookInstances.forEach((hookInstance) => {
-        hookInstance.usePlugin(plugin);
+        hookInstance.applyPlugin(plugin);
       });
     });
   }


### PR DESCRIPTION

## Description

 rename usePlugins to prevent swc react-refresh from throwing errors when replacing variables

<img width="1264" alt="img_v3_026j_8ba4da04-e6dd-461f-927b-527509a6c76g" src="https://github.com/module-federation/universe/assets/41466093/9dc7935c-594e-4198-aa09-25d1bae3bbc8">


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
