### PR TITLE
feat: add init container hook

### DIFF
--- a/.changeset/quick-chicken-glow.md
+++ b/.changeset/quick-chicken-glow.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+only both version and name matched instance can be re-use

--- a/.changeset/wet-pillows-impress.md
+++ b/.changeset/wet-pillows-impress.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+feat: add initContainer and beforeInitContainer hook

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -10,6 +10,9 @@ import {
   ShareInfos,
   UserOptions,
   RemoteInfo,
+  GlobalShareScope,
+  InitScope,
+  RemoteEntryInitOptions,
 } from './type';
 import {
   assert,
@@ -77,6 +80,21 @@ export class FederationHost {
       origin: FederationHost;
     }>('beforeRequest'),
     afterResolve: new AsyncWaterfallHook<LoadRemoteMatch>('afterResolve'),
+    beforeInitContainer: new AsyncWaterfallHook<{
+      shareScope: GlobalShareScope[string];
+      initScope: InitScope;
+      remoteEntryInitOptions: RemoteEntryInitOptions;
+      remoteInfo: RemoteInfo;
+      origin: FederationHost;
+    }>('beforeInitContainer'),
+    initContainer: new AsyncWaterfallHook<{
+      shareScope: GlobalShareScope[string];
+      initScope: InitScope;
+      remoteEntryInitOptions: RemoteEntryInitOptions;
+      remoteInfo: RemoteInfo;
+      remoteEntryExports: RemoteEntryExports;
+      origin: FederationHost;
+    }>('initContainer'),
     onLoad: new AsyncHook<
       [
         {
@@ -409,14 +427,8 @@ export class FederationHost {
     let module: Module | undefined = this.moduleCache.get(remote.name);
 
     const moduleOptions: ModuleOptions = {
-      hostInfo: {
-        name: this.options.name,
-        version: this.options.version || 'custom',
-      },
+      host: this,
       remoteInfo,
-      shared: this.options.shared || {},
-      plugins: this.options.plugins,
-      loaderHook: this.loaderHook,
     };
 
     if (!module) {

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -99,6 +99,14 @@ export function getGlobalFederationInstance(
 
     if (
       GMInstance.options.name === name &&
+      !GMInstance.options.version &&
+      !version
+    ) {
+      return true;
+    }
+
+    if (
+      GMInstance.options.name === name &&
       version &&
       GMInstance.options.version === version
     ) {

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -97,10 +97,6 @@ export function getGlobalFederationInstance(
       return true;
     }
 
-    if (GMInstance.options.name === name && !version) {
-      return true;
-    }
-
     if (
       GMInstance.options.name === name &&
       version &&

--- a/packages/runtime/src/helpers.ts
+++ b/packages/runtime/src/helpers.ts
@@ -16,6 +16,7 @@ import {
   getGlobalHostPlugins,
   getPreloaded,
   setPreloaded,
+  Global,
 } from './global';
 import { getGlobalShare, getGlobalShareScope } from './utils/share';
 
@@ -29,6 +30,7 @@ const ShareUtils: IShareUtils = {
 };
 
 interface IGlobalUtils {
+  Global: typeof Global;
   nativeGlobal: typeof global;
   resetFederationGlobalInfo: typeof resetFederationGlobalInfo;
   getGlobalFederationInstance: typeof getGlobalFederationInstance;
@@ -49,6 +51,7 @@ interface IGlobalUtils {
 }
 
 const GlobalUtils: IGlobalUtils = {
+  Global,
   nativeGlobal,
   resetFederationGlobalInfo,
   getGlobalFederationInstance,

--- a/packages/runtime/src/module/index.ts
+++ b/packages/runtime/src/module/index.ts
@@ -2,45 +2,26 @@ import { getFMId, safeToString, assert } from '../utils';
 import { getRemoteEntry } from '../utils/load';
 import { FederationHost } from '../core';
 import { Global } from '../global';
-import {
-  RemoteEntryExports,
-  Options,
-  Remote,
-  ShareInfos,
-  RemoteInfo,
-} from '../type';
-import { composeKeyWithSeparator } from '@module-federation/sdk';
+import { RemoteEntryExports, RemoteInfo, InitScope } from '../type';
 
 export type ModuleOptions = ConstructorParameters<typeof Module>[0];
 
-type HostInfo = Remote;
-
 class Module {
-  hostInfo: HostInfo;
   remoteInfo: RemoteInfo;
   inited = false;
-  shared: ShareInfos = {};
   remoteEntryExports?: RemoteEntryExports;
   lib: RemoteEntryExports | undefined = undefined;
-  loaderHook: FederationHost['loaderHook'];
-  // loading: Record<string, undefined | Promise<RemoteEntryExports | void>> = {};
+  host: FederationHost;
 
   constructor({
-    hostInfo,
     remoteInfo,
-    shared,
-    loaderHook,
+    host,
   }: {
-    hostInfo: HostInfo;
     remoteInfo: RemoteInfo;
-    shared: ShareInfos;
-    plugins: Options['plugins'];
-    loaderHook: FederationHost['loaderHook'];
+    host: FederationHost;
   }) {
-    this.hostInfo = hostInfo;
     this.remoteInfo = remoteInfo;
-    this.shared = shared;
-    this.loaderHook = loaderHook;
+    this.host = host;
   }
 
   async getEntry(): Promise<RemoteEntryExports> {
@@ -53,7 +34,7 @@ class Module {
       remoteInfo: this.remoteInfo,
       remoteEntryExports: this.remoteEntryExports,
       createScriptHook: (url: string) => {
-        const res = this.loaderHook.lifecycle.createScript.emit({ url });
+        const res = this.host.loaderHook.lifecycle.createScript.emit({ url });
         if (res instanceof HTMLScriptElement) {
           return res;
         }
@@ -84,29 +65,31 @@ class Module {
         globalShareScope[remoteShareScope] = {};
       }
       const shareScope = globalShareScope[remoteShareScope];
+      const initScope: InitScope = [];
 
-      // TODO: compat logic , it could be moved after providing startup hooks
       const remoteEntryInitOptions = {
         version: this.remoteInfo.version || '',
-        // @ts-ignore it will be passed by startup hooks
-        region: this.hostInfo.region,
       };
-      remoteEntryExports.init(shareScope, [], remoteEntryInitOptions);
-      const federationInstance = Global.__FEDERATION__.__INSTANCES__.find(
-        (i) =>
-          i.options.id ===
-          composeKeyWithSeparator(
-            this.remoteInfo.name,
-            this.remoteInfo.buildVersion,
-          ),
-      );
-      if (federationInstance) {
-        federationInstance.initOptions({
-          ...remoteEntryInitOptions,
-          remotes: [],
-          name: this.remoteInfo.name,
+
+      const initContainerOptions =
+        await this.host.hooks.lifecycle.beforeInitContainer.emit({
+          shareScope,
+          remoteEntryInitOptions,
+          initScope,
+          remoteInfo: this.remoteInfo,
+          origin: this.host,
         });
-      }
+
+      remoteEntryExports.init(
+        initContainerOptions.shareScope,
+        initContainerOptions.initScope,
+        initContainerOptions.remoteEntryInitOptions,
+      );
+
+      await this.host.hooks.lifecycle.initContainer.emit({
+        ...initContainerOptions,
+        remoteEntryExports,
+      });
     }
 
     this.lib = remoteEntryExports;

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -116,11 +116,13 @@ export type RemoteEntryInitOptions = {
   version: string;
 };
 
+export type InitScope = Array<Record<string, never>>;
+
 export type RemoteEntryExports = {
   get: (id: string) => () => Promise<Module>;
   init: (
     shareScope: GlobalShareScope[string],
-    initScope?: Array<Record<string, never>>,
+    initScope?: InitScope,
     remoteEntryInitOPtions?: RemoteEntryInitOptions,
   ) => void;
 };

--- a/packages/runtime/src/type/plugin.ts
+++ b/packages/runtime/src/type/plugin.ts
@@ -12,7 +12,7 @@ type SnapshotLifeCycleCyclePartial = Partial<{
   [k in keyof SnapshotLifeCycle]: Parameters<SnapshotLifeCycle[k]['on']>[0];
 }>;
 
-type ModuleLifeCycle = Module['loaderHook']['lifecycle'];
+type ModuleLifeCycle = Module['host']['loaderHook']['lifecycle'];
 type ModuleLifeCycleCyclePartial = Partial<{
   [k in keyof ModuleLifeCycle]: Parameters<ModuleLifeCycle[k]['on']>[0];
 }>;

--- a/packages/runtime/src/utils/plugin.ts
+++ b/packages/runtime/src/utils/plugin.ts
@@ -8,7 +8,7 @@ export function registerPlugins(
   hookInstances: Array<
     | FederationHost['hooks']
     | FederationHost['snapshotHandler']['hooks']
-    | Module['loaderHook']
+    | Module['host']['loaderHook']
   >,
 ) {
   const globalPlugins = getGlobalHostPlugins();


### PR DESCRIPTION
## Description

* add initContainer and beforeInitContainer hook
* only both version and name matched instance can be re-use

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
