### PR TITLE
fix: not duplicate set resolve.alias

### DIFF
--- a/.changeset/lemon-fans-tickle.md
+++ b/.changeset/lemon-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+fix: not duplicate set resolve.alias

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -205,13 +205,22 @@ class FederationRuntimePlugin {
         paths: [this.options.implementation],
       });
     }
+    if (Array.isArray(compiler.options.resolve.alias)) {
+      return;
+    }
 
     compiler.options.resolve.alias = {
       ...compiler.options.resolve.alias,
-      '@module-federation/runtime$': runtimePath,
-      '@module-federation/runtime-tools$':
-        this.options?.implementation || RuntimeToolsPath,
     };
+
+    if (!compiler.options.resolve.alias['@module-federation/runtime$']) {
+      compiler.options.resolve.alias['@module-federation/runtime$'] =
+        runtimePath;
+    }
+    if (!compiler.options.resolve.alias['@module-federation/runtime-tools$']) {
+      compiler.options.resolve.alias['@module-federation/runtime-tools$'] =
+        this.options?.implementation || RuntimeToolsPath;
+    }
   }
 
   apply(compiler: Compiler) {


### PR DESCRIPTION
## Description

* not duplicate set resolve.alias
In the past, if users set the same alias , it will be overrided by FederationRuntimePlugin .

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
