### PR TITLE
fix: window.location.origin will be 'null' in iframe srcDoc

### DIFF
--- a/.changeset/weak-jars-tap.md
+++ b/.changeset/weak-jars-tap.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix: window.location.origin will be "null" in iframe srcDoc

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -764,7 +764,7 @@ export class FederationHost {
         }
         // Set the remote entry to a complete path
         if ('entry' in remote) {
-          if (isBrowserEnv()) {
+          if (isBrowserEnv() && !remote.entry.startsWith('http')) {
             remote.entry = new URL(remote.entry, window.location.origin).href;
           }
         }


### PR DESCRIPTION
## Description

window.location.origin will be 'null' in iframe srcDoc
![image](https://github.com/module-federation/universe/assets/41466093/7e83c52e-0ef8-458e-8821-a6fd10dad135)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
