### PR TITLE
fix: webpackRequire.S has been attached with instance.shareScopeMap

### DIFF
--- a/.changeset/shy-spoons-cheer.md
+++ b/.changeset/shy-spoons-cheer.md
@@ -1,0 +1,9 @@
+---
+'@module-federation/webpack-bundler-runtime': patch
+'@module-federation/enhanced': patch
+'@module-federation/runtime': patch
+---
+
+fix: remove duplicate init shareScopeMap
+fix: normalize schemas path
+fix: shared is loaded if it has lib attr

--- a/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/lib/container/ModuleFederationPlugin.ts
@@ -7,7 +7,6 @@
 
 import type { Compiler, WebpackPluginInstance } from 'webpack';
 import { normalizeWebpackPath } from '@module-federation/sdk/normalize-webpack-path';
-import isValidExternalsType from 'webpack/schemas/plugins/container/ExternalsType.check.js';
 import type { ModuleFederationPluginOptions } from './ModuleFederationPluginTypes';
 import SharePlugin from '../sharing/SharePlugin';
 import ContainerPlugin from './ContainerPlugin';
@@ -15,6 +14,12 @@ import ContainerReferencePlugin from './ContainerReferencePlugin';
 import checkOptions from '../../schemas/container/ModuleFederationPlugin.check';
 import schema from '../../schemas/container/ModuleFederationPlugin';
 import FederationRuntimePlugin from './runtime/FederationRuntimePlugin';
+
+const isValidExternalsType = require(
+  normalizeWebpackPath(
+    'webpack/schemas/plugins/container/ExternalsType.check.js',
+  ),
+) as typeof import('webpack/schemas/plugins/container/ExternalsType.check.js');
 
 const createSchemaValidation = require(
   normalizeWebpackPath('webpack/lib/util/create-schema-validation'),

--- a/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
+++ b/packages/enhanced/src/lib/sharing/ConsumeSharedPlugin.ts
@@ -48,8 +48,17 @@ const createSchemaValidation = require(
 
 const validate = createSchemaValidation(
   //eslint-disable-next-line
-  require('webpack/schemas/plugins/sharing/ConsumeSharedPlugin.check.js'),
-  () => require('webpack/schemas/plugins/sharing/ConsumeSharedPlugin.json'),
+  require(
+    normalizeWebpackPath(
+      'webpack/schemas/plugins/sharing/ConsumeSharedPlugin.check.js',
+    ),
+  ),
+  () =>
+    require(
+      normalizeWebpackPath(
+        'webpack/schemas/plugins/sharing/ConsumeSharedPlugin.json',
+      ),
+    ),
   {
     name: 'Consume Shared Plugin',
     baseDataPath: 'options',

--- a/packages/runtime/src/utils/share.ts
+++ b/packages/runtime/src/utils/share.ts
@@ -105,6 +105,10 @@ const findVersion = (
   }, 0) as string;
 };
 
+const isLoaded = (shared: Shared) => {
+  return Boolean(shared.loaded) || typeof shared.lib === 'function';
+};
+
 function findSingletonVersionOrderByVersion(
   shareScopeMap: ShareScopeMap,
   scope: string,
@@ -112,7 +116,7 @@ function findSingletonVersionOrderByVersion(
 ): string {
   const versions = shareScopeMap[scope][pkgName];
   const callback = function (prev: string, cur: string): boolean {
-    return !versions[prev].loaded && versionLt(prev, cur);
+    return !isLoaded(versions[prev]) && versionLt(prev, cur);
   };
 
   return findVersion(shareScopeMap, scope, pkgName, callback);
@@ -124,15 +128,16 @@ function findSingletonVersionOrderByLoaded(
   pkgName: string,
 ): string {
   const versions = shareScopeMap[scope][pkgName];
+
   const callback = function (prev: string, cur: string): boolean {
-    if (versions[cur].loaded) {
-      if (versions[prev].loaded) {
+    if (isLoaded(versions[cur])) {
+      if (isLoaded(versions[prev])) {
         return Boolean(versionLt(prev, cur));
       } else {
         return true;
       }
     }
-    if (versions[prev].loaded) {
+    if (isLoaded(versions[prev])) {
       return false;
     }
     return versionLt(prev, cur);

--- a/packages/webpack-bundler-runtime/src/initContainerEntry.ts
+++ b/packages/webpack-bundler-runtime/src/initContainerEntry.ts
@@ -52,7 +52,6 @@ export function initContainerEntry(
 
   federationInstance.initShareScopeMap(name, shareScope);
 
-  webpackRequire.S[name] = shareScope;
   if (webpackRequire.federation.attachShareScopeMap) {
     webpackRequire.federation.attachShareScopeMap(webpackRequire);
   }


### PR DESCRIPTION
## Description

* fix: remove duplicate init shareScopeMap
* fix: normalize schemas path
* fix: shared is loaded if it has lib attr

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
