### PR TITLE
Release v0.0.9

### DIFF
--- a/.changeset/lemon-fans-tickle.md
+++ b/.changeset/lemon-fans-tickle.md
@@ -1,5 +1,0 @@
----
-'@module-federation/enhanced': patch
----
-
-fix: not duplicate set resolve.alias

--- a/.changeset/long-bulldogs-reply.md
+++ b/.changeset/long-bulldogs-reply.md
@@ -1,5 +1,0 @@
----
-'@module-federation/enhanced': patch
----
-
-fix: copy decalaration files to output

--- a/.changeset/shy-spoons-cheer.md
+++ b/.changeset/shy-spoons-cheer.md
@@ -1,9 +1,0 @@
----
-'@module-federation/webpack-bundler-runtime': patch
-'@module-federation/enhanced': patch
-'@module-federation/runtime': patch
----
-
-fix: remove duplicate init shareScopeMap
-fix: normalize schemas path
-fix: shared is loaded if it has lib attr

--- a/.changeset/weak-jars-tap.md
+++ b/.changeset/weak-jars-tap.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix: window.location.origin will be "null" in iframe srcDoc

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,17 @@
 # [0.2.0-canary.5](https://github.com/module-federation/universe/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.0.9
+
+### Patch Changes
+
+- 1147f48: fix: not duplicate set resolve.alias
+- cf8634d: fix: copy decalaration files to output
+- 2ad29a6: fix: remove duplicate init shareScopeMap
+  fix: normalize schemas path
+  fix: shared is loaded if it has lib attr
+  - @module-federation/runtime-tools@0.0.9
+  - @module-federation/sdk@0.0.9
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,18 @@
 # [8.1.0-canary.7](https://github.com/module-federation/universe/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.1.6
+
+### Patch Changes
+
+- Updated dependencies [1147f48]
+- Updated dependencies [cf8634d]
+- Updated dependencies [2ad29a6]
+- Updated dependencies [b129098]
+  - @module-federation/enhanced@0.0.9
+  - @module-federation/runtime@0.0.9
+  - @module-federation/node@2.0.7
+  - @module-federation/sdk@0.0.9
+
 ## 8.1.5
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.1.5",
+  "version": "8.1.6",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,15 @@
 # [2.1.0-canary.6](https://github.com/module-federation/universe/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.0.7
+
+### Patch Changes
+
+- Updated dependencies [1147f48]
+- Updated dependencies [cf8634d]
+- Updated dependencies [2ad29a6]
+  - @module-federation/enhanced@0.0.9
+  - @module-federation/sdk@0.0.9
+
 ## 2.0.6
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/universe/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies [2ad29a6]
+- Updated dependencies [b129098]
+  - @module-federation/webpack-bundler-runtime@0.0.9
+  - @module-federation/runtime@0.0.9
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @module-federation/runtime
 
+## 0.0.9
+
+### Patch Changes
+
+- 2ad29a6: fix: remove duplicate init shareScopeMap
+  fix: normalize schemas path
+  fix: shared is loaded if it has lib attr
+- b129098: fix: window.location.origin will be "null" in iframe srcDoc
+  - @module-federation/sdk@0.0.9
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [1.1.0-canary.1](https://github.com/module-federation/universe/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.0.9
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # [1.0.0-canary.3](https://github.com/module-federation/universe/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.0.9
+
+### Patch Changes
+
+- 2ad29a6: fix: remove duplicate init shareScopeMap
+  fix: normalize schemas path
+  fix: shared is loaded if it has lib attr
+- Updated dependencies [2ad29a6]
+- Updated dependencies [b129098]
+  - @module-federation/runtime@0.0.9
+  - @module-federation/sdk@0.0.9
+
 ## 0.0.8
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.0.9 -->

## What's Changed
### Bug Fixes 🐞
* fix(nextjs-mf): production build issues during next compile by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1940
* fix: copy decalaration files to output by @2heal1 in https://github.com/module-federation/universe/pull/1957
* fix: not duplicate set resolve.alias by @2heal1 in https://github.com/module-federation/universe/pull/1948
* fix: window.location.origin will be 'null' in iframe srcDoc by @2heal1 in https://github.com/module-federation/universe/pull/1956
* fix: webpackRequire.S has been attached with instance.shareScopeMap by @2heal1 in https://github.com/module-federation/universe/pull/1962
### Document 📖
* docs: added contribution guidelines on how to publish official versions by @zhoushaw in https://github.com/module-federation/universe/pull/1944
### Other Changes
* Release v0.0.8 by @zhoushaw in https://github.com/module-federation/universe/pull/1932
* Next Plugin Release v8.1.5 by @zhoushaw in https://github.com/module-federation/universe/pull/1945



**Full Changelog**: https://github.com/module-federation/universe/compare/v0.0.8...v0.0.9