### PR TITLE
feat(runtime): automatically complete the snapshot so that devtool can visualize it

### DIFF
--- a/packages/runtime/__tests__/hooks.spec.ts
+++ b/packages/runtime/__tests__/hooks.spec.ts
@@ -186,8 +186,8 @@ describe('hooks', () => {
     );
     assert(res);
     expect(res()).toBe('hello app2');
-    // @ts-ignore fakeSrc is local mock attr, which value is the same as src
     const testLoadedScript = [...document.querySelectorAll('script')].find(
+      // @ts-ignore fakeSrc is local mock attr, which value is the same as src
       (script) => script.fakeSrc === testRemoteEntry,
     );
     assert(testLoadedScript);

--- a/packages/runtime/__tests__/resources/snapshot/remote1/federation-manifest.json
+++ b/packages/runtime/__tests__/resources/snapshot/remote1/federation-manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "@snapshot/remote1",
+  "name": "@snapshot/remote1",
+  "metaData": {
+    "name": "@snapshot/remote1",
+    "publicPath": "http://localhost:1111/",
+    "type": "app",
+    "globalName": "@snapshot/remote1",
+    "buildInfo": {
+      "buildVersion": "custom"
+    },
+    "remoteEntry": {
+      "name": "federation-remote-entry.js",
+      "path": "resources/snapshot/remote1"
+    },
+    "types": {
+      "name": "index.d.ts",
+      "path": "./"
+    }
+  },
+  "remotes": [],
+  "shared": [],
+  "exposes": []
+}

--- a/packages/runtime/__tests__/resources/snapshot/remote1/federation-remote-entry.js
+++ b/packages/runtime/__tests__/resources/snapshot/remote1/federation-remote-entry.js
@@ -1,0 +1,11 @@
+globalThis[`@snapshot/remote1`] = {
+  get(scope) {
+    const moduleMap = {
+      './say'() {
+        return () => 'hello world "@snapshot/remote1"';
+      },
+    };
+    return moduleMap[scope];
+  },
+  init() {},
+};

--- a/packages/runtime/__tests__/resources/snapshot/remote2/federation-manifest.json
+++ b/packages/runtime/__tests__/resources/snapshot/remote2/federation-manifest.json
@@ -1,0 +1,24 @@
+{
+  "id": "@snapshot/remote2",
+  "name": "@snapshot/remote2",
+  "metaData": {
+    "name": "@snapshot/remote2",
+    "publicPath": "http://localhost:1111/",
+    "type": "app",
+    "globalName": "@snapshot/remote2",
+    "buildInfo": {
+      "buildVersion": "custom"
+    },
+    "remoteEntry": {
+      "name": "federation-remote-entry.js",
+      "path": "resources/snapshot/remote2"
+    },
+    "types": {
+      "name": "index.d.ts",
+      "path": "./"
+    }
+  },
+  "remotes": [],
+  "shared": [],
+  "exposes": []
+}

--- a/packages/runtime/__tests__/resources/snapshot/remote2/federation-remote-entry.js
+++ b/packages/runtime/__tests__/resources/snapshot/remote2/federation-remote-entry.js
@@ -1,0 +1,11 @@
+globalThis[`@snapshot/remote2`] = {
+  get(scope) {
+    const moduleMap = {
+      './say'() {
+        return () => 'hello world "@snapshot/remote2"';
+      },
+    };
+    return moduleMap[scope];
+  },
+  init() {},
+};

--- a/packages/runtime/__tests__/share.ts
+++ b/packages/runtime/__tests__/share.ts
@@ -1,4 +1,4 @@
-import { GlobalShareScope, Options } from '../src/type';
+import { GlobalShareScopeMap, Options } from '../src/type';
 export const mergeShareInfo1 = {
   name: '@federation/merge-shared',
   remotes: [],
@@ -68,6 +68,7 @@ export const localMergeShareInfos: Options['shared'] = {
     scope: ['default'],
     useIn: [],
     deps: [],
+    strategy: 'version-first',
   },
   'react-dom': {
     version: '17.0.0',
@@ -81,83 +82,6 @@ export const localMergeShareInfos: Options['shared'] = {
     scope: ['default', 'sub2'],
     useIn: [],
     deps: [],
-  },
-};
-
-export const globalMergeShareInfos: GlobalShareScope = {
-  default: {
-    react: {
-      '16.0.0': {
-        version: '16.0.0',
-        from: mergeShareInfo1.name,
-        get: mergeShareInfo1.shared.react.get,
-        shareConfig: {
-          singleton: false,
-          requiredVersion: '^16.0.0',
-          eager: false,
-        },
-        scope: ['default'],
-        useIn: [],
-        deps: [],
-      },
-    },
-    'react-dom': {
-      '17.0.0': {
-        version: '17.0.0',
-        from: mergeShareInfo2.name,
-        get: mergeShareInfo2.shared['react-dom'].get,
-        shareConfig: {
-          singleton: false,
-          requiredVersion: '^16.0.0',
-          eager: false,
-        },
-        scope: ['default', 'sub2'],
-        useIn: [],
-        deps: [],
-      },
-      '16.0.0': {
-        version: '16.0.0',
-        from: mergeShareInfo3.name,
-        get: mergeShareInfo3.shared['react-dom'].get,
-        shareConfig: {
-          singleton: false,
-          requiredVersion: '^16.0.0',
-          eager: false,
-        },
-        scope: ['default', 'sub2'],
-        useIn: [],
-        deps: [],
-      },
-    },
-  },
-  sub2: {
-    'react-dom': {
-      '16.0.0': {
-        version: '16.0.0',
-        from: mergeShareInfo3.name,
-        get: mergeShareInfo3.shared['react-dom'].get,
-        shareConfig: {
-          singleton: false,
-          requiredVersion: '^16.0.0',
-          eager: false,
-        },
-        scope: ['default', 'sub2'],
-        useIn: [],
-        deps: [],
-      },
-      '17.0.0': {
-        version: '17.0.0',
-        from: mergeShareInfo2.name,
-        get: mergeShareInfo2.shared['react-dom'].get,
-        shareConfig: {
-          singleton: false,
-          requiredVersion: '^16.0.0',
-          eager: false,
-        },
-        scope: ['default', 'sub2'],
-        useIn: [],
-        deps: [],
-      },
-    },
+    strategy: 'version-first',
   },
 };

--- a/packages/runtime/__tests__/shares.spec.ts
+++ b/packages/runtime/__tests__/shares.spec.ts
@@ -7,11 +7,10 @@ import {
   mergeShareInfo3,
   localMergeShareInfos,
 } from './share';
-import { DEFAULT_SCOPE } from '../src/constant';
 // import { assert } from '../src/utils/logger';
 import { FederationHost } from '../src/core';
-import { UserOptions, ShareScopeMap } from '../src/type';
-import { Global } from '../src/global';
+import { UserOptions, ShareScopeMap, Options } from '../src/type';
+import { Global, setGlobalFederationConstructor } from '../src/global';
 
 // eslint-disable-next-line max-lines-per-function
 // TODO: add new load share test cases
@@ -79,6 +78,7 @@ describe('shared', () => {
       version: string;
       from: string;
     }>('singleton-react');
+    assert(reactInstance);
     const reactInstanceRes = reactInstance();
     assert(reactInstanceRes, "reactInstance can't be undefined");
     expect(reactInstanceRes.from).toBe('@federation/loadShare');
@@ -88,6 +88,7 @@ describe('shared', () => {
       version: string;
       from: string;
     }>('singleton-react');
+    assert(reactInstance2);
     const reactInstance2Res = reactInstance2();
     assert(reactInstance2Res, "reactInstance can't be undefined");
     expect(reactInstance2Res.from).toBe('@federation/loadShare2');
@@ -132,6 +133,8 @@ describe('shared', () => {
         uniqueId: number;
       }>('react'),
     ]);
+    assert(reactInstance1);
+    assert(reactInstance2);
     const reactInstance1Res = reactInstance1();
     const reactInstance2Res = reactInstance2();
     assert(reactInstance1Res, "reactInstance1 can't be undefined");
@@ -191,6 +194,7 @@ describe('shared', () => {
       from: string;
       version: string;
     }>('runtime-react');
+    assert(shared);
     const sharedRes = shared();
     assert(sharedRes, "shared can't be null");
     expect(sharedRes.from).toEqual('@federation/runtime-deps2');
@@ -302,6 +306,7 @@ describe('single shared', () => {
     const shared = await FM2.loadShare<{ from: string; version: string }>(
       'runtime-react',
     );
+    assert(shared);
     const sharedRes = shared();
     assert(sharedRes, "shared can't be null");
     expect(sharedRes.from).toEqual('@shared-single/runtime-deps2');
@@ -462,7 +467,7 @@ describe('strictVersion shared', () => {
       shared: {
         'runtime-react': {
           version: '16.0.0',
-          shareConfig: {},
+          // shareConfig: {},
           get: async () => () => {
             return { from: '@shared-single/runtime-deps2' };
           },
@@ -509,7 +514,7 @@ describe('strictVersion shared', () => {
       shared: {
         'runtime-react': {
           version: '16.0.0',
-          shareConfig: {},
+          // shareConfig: {},
           lib: () => {
             return { from: '@shared-single/runtime-deps' };
           },
@@ -517,7 +522,7 @@ describe('strictVersion shared', () => {
       },
     };
 
-    const federationConfig2 = {
+    const federationConfig2: UserOptions = {
       name: '@shared-single/runtime-deps2',
       remotes: [],
       shared: {
@@ -748,7 +753,7 @@ describe('load share with customize consume info', () => {
 
 describe('load share with different strategy', () => {
   it('register all shared to shareScopeMap while strategy is "version-first"', async () => {
-    globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR__ = FederationHost;
+    setGlobalFederationConstructor(FederationHost, true);
 
     const federationConfig1: UserOptions = {
       name: '@shared-test/app1',
@@ -786,11 +791,11 @@ describe('load share with different strategy', () => {
     expect(sharedRes.from).toEqual('@shared-test/version-strategy-app2');
 
     Global.__FEDERATION__.__INSTANCES__ = [];
-    globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR__ = undefined;
+    setGlobalFederationConstructor(undefined, true);
   });
 
   it('register only self shared to shareScopeMap while strategy is "loaded-first"', async () => {
-    globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR__ = FederationHost;
+    setGlobalFederationConstructor(FederationHost, true);
 
     const federationConfig1: UserOptions = {
       name: '@shared-test/app1',
@@ -828,6 +833,6 @@ describe('load share with different strategy', () => {
     expect(sharedRes.from).toEqual('@shared-test/app1');
 
     Global.__FEDERATION__.__INSTANCES__ = [];
-    globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR__ = undefined;
+    setGlobalFederationConstructor(undefined, true);
   });
 });

--- a/packages/runtime/__tests__/snapshot.spec.ts
+++ b/packages/runtime/__tests__/snapshot.spec.ts
@@ -1,1 +1,50 @@
 import { assert, describe, it } from 'vitest';
+import { FederationHost } from '../src';
+import { getGlobalSnapshot, resetFederationGlobalInfo } from '../src/global';
+
+describe('snapshot', () => {
+  beforeEach(() => {
+    resetFederationGlobalInfo();
+  });
+
+  it('The host snapshot is automatically completed', async () => {
+    const Remote1Entry =
+      'http://localhost:1111/resources/snapshot/remote1/federation-manifest.json';
+    const Remote2Entry =
+      'http://localhost:1111/resources/snapshot/remote2/federation-manifest.json';
+    const FM1 = new FederationHost({
+      name: '@snapshot/host',
+      version: '0.0.3',
+      remotes: [
+        {
+          name: '@snapshot/remote1',
+          entry: Remote1Entry,
+        },
+        {
+          name: '@snapshot/remote2',
+          entry: Remote2Entry,
+        },
+      ],
+    });
+
+    const module = await FM1.loadRemote<() => string>('@snapshot/remote1/say');
+    assert(module);
+    expect(module()).toBe('hello world "@snapshot/remote1"');
+
+    const module2 = await FM1.loadRemote<() => string>('@snapshot/remote2/say');
+    assert(module2);
+    expect(module2()).toBe('hello world "@snapshot/remote2"');
+
+    const globalSnapshot = getGlobalSnapshot();
+
+    // console.log('xxxxx', globalSnapshot);
+    assert(globalSnapshot['@snapshot/host']);
+    expect(globalSnapshot['@snapshot/host']).toMatchObject({
+      version: '0.0.3',
+      remotesInfo: {
+        '@snapshot/remote1': { matchedVersion: Remote1Entry },
+        '@snapshot/remote2': { matchedVersion: Remote2Entry },
+      },
+    });
+  });
+});

--- a/packages/runtime/__tests__/snapshot.spec.ts
+++ b/packages/runtime/__tests__/snapshot.spec.ts
@@ -1,0 +1,1 @@
+import { assert, describe, it } from 'vitest';

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -154,91 +154,85 @@ export function setGlobalFederationConstructor(
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-export function getInfoWithoutType<T extends object>(
+function getInfoWithoutType<T extends object>(
   target: T,
   key: keyof T,
-  getModuleInfoHook?: (
-    target: any,
-    key: string | number | symbol,
-  ) => { value: any | undefined; key: string } | void,
 ): { value: T[keyof T] | undefined; key: string } {
-  let res: { value: T[keyof T] | undefined; key: string } = {
+  return {
     value: target[key],
     key: key as string,
   };
+}
 
-  if (getModuleInfoHook) {
-    const hookRes = getModuleInfoHook(target, key);
-    res = hookRes || res;
+export class GetSnapshotInfoWithHook {
+  loaderHook: FederationHost['loaderHook'];
+  constructor(loaderHook: FederationHost['loaderHook']) {
+    this.loaderHook = loaderHook;
   }
-  return res;
+  getInfoWithoutTypeWithHook<T extends object>(target: T, key: keyof T) {
+    let res = getInfoWithoutType(target, key);
+    const hookRes = this.loaderHook.lifecycle.getModuleInfo.emit({
+      target,
+      key,
+    });
+    if (hookRes && !(hookRes instanceof Promise)) {
+      res = hookRes || res;
+    }
+    return res;
+  }
+
+  getTargetSnapshotInfoByModuleInfo(
+    moduleInfo: Optional<Remote, 'alias'>,
+    snapshot: GlobalModuleInfo,
+  ) {
+    // Check if the remote is included in the hostSnapshot
+    const moduleKey = getFMId(moduleInfo);
+    const getModuleInfo = this.getInfoWithoutTypeWithHook(
+      snapshot,
+      moduleKey,
+    ).value;
+
+    // The remoteSnapshot might not include a version
+    if (
+      getModuleInfo &&
+      !getModuleInfo.version &&
+      'version' in moduleInfo &&
+      moduleInfo['version']
+    ) {
+      getModuleInfo.version = moduleInfo['version'];
+    }
+
+    if (getModuleInfo) {
+      return getModuleInfo;
+    }
+
+    // If the remote is not included in the hostSnapshot, deploy a micro app snapshot
+    if ('version' in moduleInfo && moduleInfo['version']) {
+      const { version, ...resModuleInfo } = moduleInfo;
+      const moduleKeyWithoutVersion = getFMId(resModuleInfo);
+      const getModuleInfoWithoutVersion = this.getInfoWithoutTypeWithHook(
+        nativeGlobal.__FEDERATION__.moduleInfo,
+        moduleKeyWithoutVersion,
+      ).value;
+
+      if (getModuleInfoWithoutVersion?.version === version) {
+        return getModuleInfoWithoutVersion;
+      }
+    }
+
+    return;
+  }
+
+  getGlobalSnapshotInfoByModuleInfo(moduleInfo: Optional<Remote, 'alias'>) {
+    return this.getTargetSnapshotInfoByModuleInfo(
+      moduleInfo,
+      nativeGlobal.__FEDERATION__.moduleInfo,
+    );
+  }
 }
 
 export const getGlobalSnapshot = (): GlobalModuleInfo =>
   nativeGlobal.__FEDERATION__.moduleInfo;
-
-export const getTargetSnapshotInfoByModuleInfo = (
-  moduleInfo: Optional<Remote, 'alias'>,
-  snapshot: GlobalModuleInfo,
-  getModuleInfoHook?: (
-    target: any,
-    key: string | number | symbol,
-  ) => { value: any | undefined; key: string } | void,
-): GlobalModuleInfo[string] | undefined => {
-  // Check if the remote is included in the hostSnapshot
-  const moduleKey = getFMId(moduleInfo);
-  const getModuleInfo = getInfoWithoutType(
-    snapshot,
-    moduleKey,
-    getModuleInfoHook,
-  ).value;
-
-  // The remoteSnapshot might not include a version
-  if (
-    getModuleInfo &&
-    !getModuleInfo.version &&
-    'version' in moduleInfo &&
-    moduleInfo['version']
-  ) {
-    getModuleInfo.version = moduleInfo['version'];
-  }
-
-  if (getModuleInfo) {
-    return getModuleInfo;
-  }
-
-  // If the remote is not included in the hostSnapshot, deploy a micro app snapshot
-  if ('version' in moduleInfo && moduleInfo['version']) {
-    const { version, ...resModuleInfo } = moduleInfo;
-    const moduleKeyWithoutVersion = getFMId(resModuleInfo);
-    const getModuleInfoWithoutVersion = getInfoWithoutType(
-      nativeGlobal.__FEDERATION__.moduleInfo,
-      moduleKeyWithoutVersion,
-      getModuleInfoHook,
-    ).value;
-
-    if (getModuleInfoWithoutVersion?.version === version) {
-      return getModuleInfoWithoutVersion;
-    }
-  }
-
-  return;
-};
-
-export const getGlobalSnapshotInfoByModuleInfo = (
-  moduleInfo: Optional<Remote, 'alias'>,
-  extraOptions?: {
-    getModuleInfoHook?: (
-      target: any,
-      key: string | number | symbol,
-    ) => { value: any | undefined; key: string } | void;
-  },
-): GlobalModuleInfo[string] | undefined =>
-  getTargetSnapshotInfoByModuleInfo(
-    moduleInfo,
-    nativeGlobal.__FEDERATION__.moduleInfo,
-    extraOptions?.getModuleInfoHook,
-  );
 
 export const setGlobalSnapshotInfoByModuleInfo = (
   remoteInfo: Remote,

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -144,9 +144,10 @@ export function getGlobalFederationConstructor():
 }
 
 export function setGlobalFederationConstructor(
-  FederationConstructor: typeof FederationHost,
+  FederationConstructor: typeof FederationHost | undefined,
+  isDebug = isDebugMode(),
 ): void {
-  if (isDebugMode()) {
+  if (isDebug) {
     globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR__ = FederationConstructor;
     globalThis.__FEDERATION__.__DEBUG_CONSTRUCTOR_VERSION__ = __VERSION__;
   }

--- a/packages/runtime/src/module/index.ts
+++ b/packages/runtime/src/module/index.ts
@@ -33,6 +33,7 @@ class Module {
       remoteInfo: this.remoteInfo,
       remoteEntryExports: this.remoteEntryExports,
       createScriptHook: (url: string) => {
+        console.log('xxxxxxx', this.host.loaderHook);
         const res = this.host.loaderHook.lifecycle.createScript.emit({ url });
         if (typeof document === 'undefined') {
           //todo: needs real fix

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -55,11 +55,11 @@ type SharedBaseArgs = {
   strategy?: 'version-first' | 'loaded-first';
 };
 
-export type ShareArgs =
-  | (SharedBaseArgs & { get: () => () => Module | Promise<() => Module> })
-  | (SharedBaseArgs & { lib: () => Module });
+export type SharedGetter = (() => () => Module) | (() => Promise<() => Module>);
 
-export type SharedGetter = () => () => Promise<() => Module> | Module;
+export type ShareArgs =
+  | (SharedBaseArgs & { get: SharedGetter })
+  | (SharedBaseArgs & { lib: () => Module });
 
 export type Shared = {
   version: string;

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
   plugins: [nxViteTsPaths()],
   test: {
     environment: 'jsdom',
-    include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
+    // include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
+    include: [path.resolve(__dirname, '__tests__/snapshot.spec.ts')],
     globals: true,
     setupFiles: [path.resolve(__dirname, './__tests__/setup.ts')],
     testTimeout: 10000,

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   plugins: [nxViteTsPaths()],
   test: {
     environment: 'jsdom',
-    // include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
-    include: [path.resolve(__dirname, '__tests__/snapshot.spec.ts')],
+    include: [path.resolve(__dirname, '__tests__/*.spec.ts')],
+    // include: [path.resolve(__dirname, '__tests__/snapshot.spec.ts')],
     globals: true,
     setupFiles: [path.resolve(__dirname, './__tests__/setup.ts')],
     testTimeout: 10000,


### PR DESCRIPTION
## Description

* When a consumer does not have a snapshot, the snapshot is not automatically replenished, and subsequent devtool cannot visually query dependencies
* Optimize the logic for getting snapshots and hooks

## Related Issue

#1933 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
