### PR TITLE
feat(runtime): allow onload hook to return wrapped module

### DIFF
--- a/.changeset/fast-sheep-melt.md
+++ b/.changeset/fast-sheep-melt.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+onLoad hook will allow you to return a custom module factory or proxy

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -571,7 +571,7 @@ export class FederationHost {
       const { pkgNameOrAlias, remote, expose, id: idRes } = remoteMatchInfo;
       const moduleOrFactory = (await module.get(expose, options)) as T;
 
-      await this.hooks.lifecycle.onLoad.emit({
+      const moduleWrapper = await this.hooks.lifecycle.onLoad.emit({
         id: idRes,
         pkgNameOrAlias,
         expose,
@@ -582,6 +582,10 @@ export class FederationHost {
         moduleInstance: module,
         origin: this,
       });
+
+      if (typeof moduleWrapper === 'function') {
+        return moduleWrapper as T;
+      }
 
       return moduleOrFactory;
     } catch (error) {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Allows export proxies and wrappers around the module that is loaded. 

<!--- Describe your changes in detail -->
This enables things like SSR, where we can track function invocation not chunk load to register args.id from the onload hook. 
This allows us to return preload scripts in DOM with server rendering etc.  
Allows wrapping in error boundaries or adapters 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/module-federation/universe/pull/1985
https://github.com/module-federation/universe/issues/1984

the terminal is displaying logs in repetition for each time it is executed again.  Able to intercept exports function calls 
<img width="1600" alt="image" src="https://github.com/module-federation/universe/assets/25274700/edf88252-74ac-4476-a7ea-51ebd1fbdd9c">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
