### PR TITLE
feat(typescript): convert plugin to unplugin for rspack support

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -1,6 +1,6 @@
 # Federated Types
 
-This plugin enables **Typescript Types** support for Module Federated Components.
+This plugin enables **Typescript Types** support for Module Federated Components in both webpack and rspack.
 
 ## Installation
 
@@ -8,13 +8,14 @@ This plugin enables **Typescript Types** support for Module Federated Components
 $ npm i @module-federation/typescript
 ```
 
-## Usage
+## Rspack
 
-Register the plugin in `webpack configuration (webpack.config.js)` file
+## Webpack
+
+Register the plugin in `rspack configuration (rspack.config.js)` file
 
 ```typescript
-import webpack from 'webpack';
-const { FederatedTypesPlugin } = require('@module-federation/typescript');
+const { FederatedTypes } = require('@module-federation/typescript');
 
 const federationConfig = {
   name: 'my-app',
@@ -34,13 +35,49 @@ module.exports = {
   /* ... */
   plugins: [
     // ...
-    new FederatedTypesPlugin({
+    FederatedTypes.rspack({
       federationConfig,
       // ...
     }),
   ],
 };
 ```
+
+## Webpack
+
+Register the plugin in `webpack configuration (webpack.config.js)` file
+
+```typescript
+import webpack from 'webpack';
+const { FederatedTypes } = require('@module-federation/typescript');
+
+const federationConfig = {
+  name: 'my-app',
+  filename: 'remoteEntry.js',
+  exposes: {
+    //...exposed components
+    './Button': './src/Button',
+    './Input': './src/Input',
+  },
+  remotes: {
+    app2: 'app2@http://localhost:3002/remoteEntry.js', // or Just the URL 'http://localhost:3002'
+  },
+  shared: ['react', 'react-dom'],
+};
+
+module.exports = {
+  /* ... */
+  plugins: [
+    // ...
+    FederatedTypes.webpack({
+      federationConfig,
+      // ...
+    }),
+  ],
+};
+```
+
+## Additional configuration
 
 If you are running multiple remotes that use bi-directional module sharing, you may run into race conditions while starting up the webpack-dev-servers. The library now supports configuring retry options (which are enabled by default), along with the ability to serve the types out of the webpack compiler in a separate HTTP host.
 
@@ -51,7 +88,7 @@ module.exports = {
   /* ... */
   plugins: [
     // ...
-    new FederatedTypesPlugin({
+    FederatedTypes(.rspack or .webpack){
       federationConfig,
       typeFetchOptions: {
         /** The maximum time to wait for downloading remote types in milliseconds.
@@ -131,12 +168,12 @@ Sample code:
 
 ```typescript
 // next.config.js
-const FederatedTypesPlugin = require('@module-federation/typescript');
+const { FederatedTypes } = require('@module-federation/typescript');
 
 module.exports = {
   webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
     config.plugins.push(
-      new FederatedTypesPlugin({
+      FederatedTypes.webpack({
         federationConfig: {
           ...federationConfig,
           remotes: { app2: 'app2@http://localhost:3000/remoteEntry.js' },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/typescript",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Webpack plugin to stream typescript for module federation apps/components",
   "license": "MIT",
   "type": "commonjs",
@@ -34,7 +34,8 @@
     "react-dom": "*"
   },
   "dependencies": {
-    "node-fetch": "2.7.0"
+    "node-fetch": "2.7.0",
+    "unplugin": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -52,8 +53,16 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/src/index.js",
-      "types": "./dist/src/index.d.ts"
+      "require": "./src/index.js",
+      "types": "./src/index.d.ts"
+    },
+    "./webpack": {
+      "types": "./src/webpack.d.ts",
+      "require": "./src/webpack.js"
+    },
+    "./rspack": {
+      "types": "./src/rspack.d.ts",
+      "require": "./src/rspack.js"
     }
   }
 }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,4 +1,19 @@
+import { createUnplugin } from 'unplugin';
+import { FederatedTypesPluginOptions } from './types';
 import { FederatedTypesPlugin } from './plugins/FederatedTypesPlugin';
 
-export { FederatedTypesPlugin };
-export default FederatedTypesPlugin;
+export const FederatedTypes = createUnplugin(
+  (options: FederatedTypesPluginOptions) => {
+    return {
+      name: 'FederatedTypes',
+      webpack: (compiler) => {
+        const federatedTypesPlugin = new FederatedTypesPlugin(options);
+        federatedTypesPlugin.apply(compiler);
+      },
+      rspack: (compiler) => {
+        const federatedTypesPlugin = new FederatedTypesPlugin(options);
+        federatedTypesPlugin.apply(compiler);
+      },
+    };
+  },
+);

--- a/packages/typescript/src/rspack.ts
+++ b/packages/typescript/src/rspack.ts
@@ -1,0 +1,3 @@
+import { FederatedTypes } from '.';
+
+export const FederatedTypesPlugin = FederatedTypes.rspack;

--- a/packages/typescript/src/webpack.ts
+++ b/packages/typescript/src/webpack.ts
@@ -1,0 +1,3 @@
+import { FederatedTypes } from '.';
+
+export const FederatedTypesPlugin = FederatedTypes.webpack;

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "force": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -962,12 +962,60 @@ importers:
       typescript:
         specifier: '*'
         version: 5.1.6
+      unplugin:
+        specifier: ^1.6.0
+        version: 1.6.0
       vue-tsc:
         specifier: ^1.0.24
         version: 1.8.22(typescript@5.1.6)
       webpack:
         specifier: ^5.75.0
         version: 5.88.2(@swc/core@1.3.102)(esbuild@0.19.11)
+
+  packages/typescript/dist:
+    dependencies:
+      '@module-federation/utilities':
+        specifier: 3.0.5
+        version: link:../../utilities
+      axios:
+        specifier: 1.6.5
+        version: 1.6.5
+      lodash.get:
+        specifier: 4.4.2
+        version: 4.4.2
+      next:
+        specifier: '*'
+        version: 13.5.6(react-dom@18.2.0)(react@18.2.0)
+      node-fetch:
+        specifier: 2.7.0
+        version: 2.7.0
+      react:
+        specifier: '*'
+        version: 18.2.0
+      react-dom:
+        specifier: '*'
+        version: 18.2.0(react@18.2.0)
+      tapable:
+        specifier: 2.2.1
+        version: 2.2.1
+      typescript:
+        specifier: '*'
+        version: 5.3.3
+      unplugin:
+        specifier: ^1.6.0
+        version: 1.6.0
+      util:
+        specifier: 0.11.1
+        version: 0.11.1
+      vue-tsc:
+        specifier: ^1.0.24
+        version: 1.8.27(typescript@5.3.3)
+      webpack:
+        specifier: ^5.75.0
+        version: 5.89.0
+      webpack-sources:
+        specifier: 3.2.3
+        version: 3.2.3
 
   packages/utilities:
     dependencies:
@@ -10053,7 +10101,6 @@ packages:
 
   /@types/node@20.5.1:
     resolution: {integrity: sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==}
-    dev: true
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -10659,7 +10706,6 @@ packages:
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
     dependencies:
       '@volar/source-map': 1.11.1
-    dev: true
 
   /@volar/source-map@1.10.10:
     resolution: {integrity: sha512-GVKjLnifV4voJ9F0vhP56p4+F3WGf+gXlRtjFZsv6v3WxBTWU3ZVeaRaEHJmWrcv5LXmoYYpk/SC25BKemPRkg==}
@@ -10671,7 +10717,6 @@ packages:
     resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
     dependencies:
       muggle-string: 0.3.1
-    dev: true
 
   /@volar/typescript@1.10.10:
     resolution: {integrity: sha512-4a2r5bdUub2m+mYVnLu2wt59fuoYWe7nf0uXtGHU8QQ5LDNfzAR0wK7NgDiQ9rcl2WT3fxT2AA9AylAwFtj50A==}
@@ -10685,7 +10730,6 @@ packages:
     dependencies:
       '@volar/language-core': 1.11.1
       path-browserify: 1.0.1
-    dev: true
 
   /@vscode/gulp-vinyl-zip@2.5.0:
     resolution: {integrity: sha512-PP/xkOoLBSY3V04HmzRxF+NOxkRJ/m2D0YwWpfx1FCFv5G8+sZUGPvxX+LRgdJ5vQcR1RHck5x1IkHi75Qjdbw==}
@@ -10751,7 +10795,6 @@ packages:
       path-browserify: 1.0.1
       typescript: 5.3.3
       vue-template-compiler: 2.7.15
-    dev: true
 
   /@vue/shared@3.3.11:
     resolution: {integrity: sha512-u2G8ZQ9IhMWTMXaWqZycnK4UthG1fA238CD+DP4Dm4WJi5hdUKKLg0RMRaRpDPNMdkTwIDkp7WtD0Rd9BH9fLw==}
@@ -12425,7 +12468,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001570
+      caniuse-lite: 1.0.30001579
       electron-to-chromium: 1.4.613
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.2)
@@ -12689,7 +12732,6 @@ packages:
 
   /caniuse-lite@1.0.30001579:
     resolution: {integrity: sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==}
-    dev: true
 
   /cardinal@2.1.1:
     resolution: {integrity: sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==}
@@ -17796,7 +17838,6 @@ packages:
 
   /inherits@2.0.3:
     resolution: {integrity: sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==}
-    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -19028,7 +19069,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.19.8
+      '@types/node': 20.5.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -20995,6 +21036,45 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
+  /next@13.5.6(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==}
+    engines: {node: '>=16.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 13.5.6
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001579
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
+      watchpack: 2.4.0
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 13.5.6
+      '@next/swc-darwin-x64': 13.5.6
+      '@next/swc-linux-arm64-gnu': 13.5.6
+      '@next/swc-linux-arm64-musl': 13.5.6
+      '@next/swc-linux-x64-gnu': 13.5.6
+      '@next/swc-linux-x64-musl': 13.5.6
+      '@next/swc-win32-arm64-msvc': 13.5.6
+      '@next/swc-win32-ia32-msvc': 13.5.6
+      '@next/swc-win32-x64-msvc': 13.5.6
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: false
+
   /ngx-deploy-npm@7.1.0(@nx/devkit@17.2.8)(tslib@2.6.2):
     resolution: {integrity: sha512-zUv/C9giRVrhmOu3dIG3tjjN+1/bOV5xQzPGgXBZL74M5dgZo+/Dui1JxrVCZH9m8QogR4Zg+0Xq6FeXo2xKrg==}
     engines: {node: '>=18.0.0'}
@@ -21053,6 +21133,18 @@ packages:
       encoding: 0.1.13
       whatwg-url: 5.0.0
     dev: true
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
 
   /node-fetch@2.7.0(encoding@0.1.13):
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -26330,6 +26422,23 @@ packages:
       client-only: 0.0.1
       react: 18.2.0
 
+  /styled-jsx@5.1.1(react@18.2.0):
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+    dev: false
+
   /styled-jsx@5.1.2(@babel/core@7.23.6)(react@18.2.0):
     resolution: {integrity: sha512-FI5r0a5ED2/+DSdG2ZRz3a4FtNQnKPLadauU5v76a9QsscwZrWggQKOmyxGGP5EWKbyY3bsuWAJYzyKaDAVAcw==}
     engines: {node: '>= 12.0.0'}
@@ -26772,6 +26881,30 @@ packages:
       terser: 5.26.0
       webpack: 5.89.0(@swc/core@1.3.102)(esbuild@0.19.11)
     dev: true
+
+  /terser-webpack-plugin@5.3.9(webpack@5.89.0):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.20
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.26.0
+      webpack: 5.89.0
+    dev: false
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -27956,7 +28089,6 @@ packages:
     resolution: {integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==}
     dependencies:
       inherits: 2.0.3
-    dev: true
 
   /util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
@@ -28530,7 +28662,6 @@ packages:
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       semver: 7.5.4
       typescript: 5.3.3
-    dev: true
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
@@ -28850,6 +28981,46 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  /webpack@5.89.0:
+    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.11.2
+      acorn-import-assertions: 1.9.0(acorn@8.11.2)
+      browserslist: 4.22.2
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.4.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: false
 
   /webpack@5.89.0(@swc/core@1.3.102)(esbuild@0.18.20):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}


### PR DESCRIPTION
## Description

Convert the federated types plugin to unplugin to support rspack and webpack.

## Related Issue

N/A

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

Tested via symlink (pnpm link) in both a webpack and rspack project. Bumped version to 3.2.0.

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have updated the documentation.
