### PR TITLE
Release v0.0.10

### DIFF
--- a/.changeset/curly-mangos-worry.md
+++ b/.changeset/curly-mangos-worry.md
@@ -1,5 +1,0 @@
----
-'@module-federation/nextjs-mf': patch
----
-
-Remove default delegate module files, as well as remove the delegate loaders. Replaced by runtimePlugins

--- a/.changeset/fast-sheep-melt.md
+++ b/.changeset/fast-sheep-melt.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-onLoad hook will allow you to return a custom module factory or proxy

--- a/.changeset/metal-walls-drop.md
+++ b/.changeset/metal-walls-drop.md
@@ -1,5 +1,0 @@
----
-'@module-federation/enhanced': patch
----
-
-Fix bug in AyncBoundaryPlugin when chunkID is not set to named and dependOn exists

--- a/.changeset/modern-snails-chew.md
+++ b/.changeset/modern-snails-chew.md
@@ -1,5 +1,0 @@
----
-'@module-federation/node': patch
----
-
-Refactor AutomaticPublicPath plugin to use federation global manager for auto path resolution in node.js

--- a/.changeset/odd-tomatoes-fetch.md
+++ b/.changeset/odd-tomatoes-fetch.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-feat(runtime): automatically complete the snapshot so that devtool can visualize it

--- a/.changeset/popular-spoons-grin.md
+++ b/.changeset/popular-spoons-grin.md
@@ -1,6 +1,0 @@
----
-'@module-federation/nextjs-mf': patch
-'@module-federation/node': patch
----
-
-Rewrite chunk flushing and hot reloading to use federation runtime apis

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [0.2.0-canary.5](https://github.com/module-federation/universe/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.0.10
+
+### Patch Changes
+
+- 51b18e0: Fix bug in AyncBoundaryPlugin when chunkID is not set to named and dependOn exists
+  - @module-federation/runtime-tools@0.0.10
+  - @module-federation/sdk@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,21 @@
 # [8.1.0-canary.7](https://github.com/module-federation/universe/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.1.7
+
+### Patch Changes
+
+- 8e35e49: Remove default delegate module files, as well as remove the delegate loaders. Replaced by runtimePlugins
+- 73eb07e: Rewrite chunk flushing and hot reloading to use federation runtime apis
+- Updated dependencies [2d774d1]
+- Updated dependencies [51b18e0]
+- Updated dependencies [2b34e46]
+- Updated dependencies [2097daa]
+- Updated dependencies [73eb07e]
+  - @module-federation/runtime@0.0.10
+  - @module-federation/enhanced@0.0.10
+  - @module-federation/node@2.0.8
+  - @module-federation/sdk@0.0.10
+
 ## 8.1.6
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.1.6",
+  "version": "8.1.7",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,18 @@
 # [2.1.0-canary.6](https://github.com/module-federation/universe/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.0.8
+
+### Patch Changes
+
+- 2b34e46: Refactor AutomaticPublicPath plugin to use federation global manager for auto path resolution in node.js
+- 73eb07e: Rewrite chunk flushing and hot reloading to use federation runtime apis
+- Updated dependencies [2d774d1]
+- Updated dependencies [51b18e0]
+- Updated dependencies [2097daa]
+  - @module-federation/runtime@0.0.10
+  - @module-federation/enhanced@0.0.10
+  - @module-federation/sdk@0.0.10
+
 ## 2.0.7
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/universe/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [2d774d1]
+- Updated dependencies [2097daa]
+  - @module-federation/runtime@0.0.10
+  - @module-federation/webpack-bundler-runtime@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/runtime
 
+## 0.0.10
+
+### Patch Changes
+
+- 2d774d1: onLoad hook will allow you to return a custom module factory or proxy
+- 2097daa: feat(runtime): automatically complete the snapshot so that devtool can visualize it
+  - @module-federation/sdk@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [1.1.0-canary.1](https://github.com/module-federation/universe/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.0.10
+
 ## 0.0.9
 
 ## 0.0.8

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [1.0.0-canary.3](https://github.com/module-federation/universe/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [2d774d1]
+- Updated dependencies [2097daa]
+  - @module-federation/runtime@0.0.10
+  - @module-federation/sdk@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
## What's Changed
### New Features 🎉
* feat(runtime): allow onload hook to return wrapped module by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1987
* feat(runtime): automatically complete the snapshot so that devtool can visualize it by @zhoushaw in https://github.com/module-federation/universe/pull/1982
### Bug Fixes 🐞
* fix(enhanced): async boundary on dependOn named chunks by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1960
* fix(nextjs-mf): remove delegate code by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1938
* fix(node): Improve chunk flushing by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1985
### Other Changes
* Release v0.0.9 by @zhoushaw in https://github.com/module-federation/universe/pull/1965
* chore: disable unreliable e2e of next project by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1972
* chore(deps): update dependency @types/react to v18.2.48 by @renovate in https://github.com/module-federation/universe/pull/1954
* chore: remove isolated config by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1977
* ci: improve e2e stability of next by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1979
* fi(node): AutoPublicPath plugin to use federation api to calculate public path automatically by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/1983
* chore: update next build commands in CI by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/2000


**Full Changelog**: https://github.com/module-federation/universe/compare/v0.0.9...v0.0.10