### PR TITLE
fix(runtime): support restricted unsafe-eval environments

### DIFF
--- a/packages/runtime/__tests__/preload-remote.spec.ts
+++ b/packages/runtime/__tests__/preload-remote.spec.ts
@@ -237,7 +237,7 @@ describe('preload-remote inBrowser', () => {
   beforeEach(() => {
     document.head.innerHTML = '';
     document.body.innerHTML = '';
-    Global.__FEDERATION__.__PRELOADED_MAP__.clear();
+    globalThis.__FEDERATION__.__PRELOADED_MAP__.clear();
   });
 
   const FMInstance = init({
@@ -284,12 +284,14 @@ describe('preload-remote inBrowser', () => {
     ]);
 
     expect(getPreloadElInfos()).toMatchSnapshot();
-    expect(Global.__FEDERATION__.__PRELOADED_MAP__.size).toBe(2);
+    expect(globalThis.__FEDERATION__.__PRELOADED_MAP__.size).toBe(2);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get('@federation/sub1/button'),
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get(
+        '@federation/sub1/button',
+      ),
     ).toBe(true);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get(
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get(
         '@federation/sub1-button/button',
       ),
     ).toBe(true);
@@ -307,17 +309,21 @@ describe('preload-remote inBrowser', () => {
     ]);
 
     expect(getPreloadElInfos()).toMatchSnapshot();
-    expect(Global.__FEDERATION__.__PRELOADED_MAP__.size).toBe(3);
+    expect(globalThis.__FEDERATION__.__PRELOADED_MAP__.size).toBe(3);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get('@federation/sub2/button'),
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get(
+        '@federation/sub2/button',
+      ),
     ).toBe(true);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get(
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get(
         '@federation/sub2-button/button',
       ),
     ).toBe(true);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get('@federation/sub2-add/add'),
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get(
+        '@federation/sub2-add/add',
+      ),
     ).toBe(true);
     reset();
   });
@@ -325,7 +331,7 @@ describe('preload-remote inBrowser', () => {
   it('3 preload with expose config ', async () => {
     const reset = addGlobalSnapshot(mockSnapshot);
 
-    expect(Global.__FEDERATION__.__PRELOADED_MAP__.size).toBe(0);
+    expect(globalThis.__FEDERATION__.__PRELOADED_MAP__.size).toBe(0);
     await FMInstance.preloadRemote([
       {
         nameOrAlias: '@federation/sub3',
@@ -334,9 +340,10 @@ describe('preload-remote inBrowser', () => {
       },
     ]);
     expect(getPreloadElInfos()).toMatchSnapshot();
-    expect(Global.__FEDERATION__.__PRELOADED_MAP__.size).toBe(1);
+
+    expect(globalThis.__FEDERATION__.__PRELOADED_MAP__.size).toBe(1);
     expect(
-      Global.__FEDERATION__.__PRELOADED_MAP__.get('@federation/sub3/add'),
+      globalThis.__FEDERATION__.__PRELOADED_MAP__.get('@federation/sub3/add'),
     ).toBe(true);
 
     await FMInstance.preloadRemote([

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -22,8 +22,14 @@ export interface Federation {
   __PRELOADED_MAP__: Map<string, boolean>;
 }
 
-// export const nativeGlobal: typeof global = new Function('return this')();
-export const nativeGlobal: typeof global = new Function('return this')();
+export const nativeGlobal: typeof global = (() => {
+  try {
+    return new Function('return this');
+  } catch {
+    return globalThis;
+  }
+})() as typeof global;
+
 export const Global = nativeGlobal;
 
 declare global {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Prevent runtime error when unsafe-eval is restricted by policy
<!--- Describe your changes in detail -->
Webpack may transform globalThis into require.g, but that will be something the end user must manage if they cannot support unsafe-eval policy on runtime scripts. 

Try to use new function and catch and return whatever globalThis is 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#2015
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
