### PR TITLE
fix(3000-home): add trailing slash on antd and lodash shared config

### DIFF
--- a/apps/3000-home/next.config.js
+++ b/apps/3000-home/next.config.js
@@ -2,7 +2,7 @@ const { withNx } = require('@nx/next/plugins/with-nx');
 const NextFederationPlugin = require('@module-federation/nextjs-mf');
 
 /**
- * @type {import('@nrwl/next/plugins/with-nx').WithNxOptions}
+ * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
  **/
 const nextConfig = {
   nx: {
@@ -39,8 +39,8 @@ const nextConfig = {
           './menu': './components/menu',
         },
         shared: {
-          lodash: {},
-          antd: {},
+          'lodash/': {},
+          'antd/': {},
         },
         extraOptions: {
           debug: false,

--- a/apps/3000-home/pages/index.tsx
+++ b/apps/3000-home/pages/index.tsx
@@ -93,7 +93,7 @@ const Home = () => {
             <td>
               Load federated component from checkout with old antd version
             </td>
-            <td>[Button from antd@4.20.0]</td>
+            <td>[Button from antd@4.24.15]</td>
             <td>
               <Suspense fallback="loading ButtonOldAnt">
                 <ButtonOldAnt />

--- a/apps/3001-shop/next.config.js
+++ b/apps/3001-shop/next.config.js
@@ -31,8 +31,8 @@ const nextConfig = {
           './menu': './components/menu',
         },
         shared: {
-          lodash: {},
-          antd: {},
+          'lodash/': {},
+          'antd/': {},
         },
         extraOptions: {
           exposePages: true,

--- a/apps/3002-checkout/next.config.js
+++ b/apps/3002-checkout/next.config.js
@@ -30,8 +30,8 @@ const nextConfig = {
           './menu': './components/menu',
         },
         shared: {
-          lodash: {},
-          antd: {},
+          'lodash/': {},
+          'antd/': {},
         },
         extraOptions: {
           exposePages: true,


### PR DESCRIPTION
## Description

Added a trailing slash to the shared config on the examples from `3000-home`, `3001-shop`, and `3002-checkout` that were using the Next.js plugin.
The slash is needed for them to be properly shared since it will cause webpack to partially match the [optimization](https://nextjs.org/docs/app/api-reference/next-config-js/optimizePackageImports) of the imports that Next.js started doing since 13.5 to some packages.

## Related Issue

This should solve https://github.com/module-federation/universe/issues/2037.

## Types of changes

- [X] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the documentation. (No doc to update)
