### PR TITLE
fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first'

### DIFF
--- a/.changeset/hip-cars-drop.md
+++ b/.changeset/hip-cars-drop.md
@@ -2,4 +2,4 @@
 '@module-federation/runtime': patch
 ---
 
-fix(runtime): runtime should not pre-register shared while shared is loading
+fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first'

--- a/.changeset/hip-cars-drop.md
+++ b/.changeset/hip-cars-drop.md
@@ -2,4 +2,4 @@
 '@module-federation/runtime': patch
 ---
 
-fix(runtime): runtime should not pre-register shared while strategy is loaded-first
+fix(runtime): runtime should not pre-register shared while shared is loading

--- a/.changeset/hip-cars-drop.md
+++ b/.changeset/hip-cars-drop.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): runtime should not pre-register shared while strategy is loaded-first

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -650,7 +650,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   initializeSharing(
     shareScopeName = DEFAULT_SCOPE,
-    strategy: Shared['strategy'] = 'version-first',
+    strategy?: Shared['strategy'],
   ): Array<Promise<void>> {
     const shareScope = this.shareScopeMap;
     const hostName = this.options.name;
@@ -671,7 +671,8 @@ export class FederationHost {
       );
       if (
         !activeVersion ||
-        (!activeVersion.loaded &&
+        (!activeVersion.loading &&
+          !activeVersion.loaded &&
           (Boolean(!eager) !== !activeVersionEager
             ? eager
             : hostName > activeVersion.from))
@@ -693,15 +694,13 @@ export class FederationHost {
         }
       }
     };
-
+    Object.keys(this.options.shared).forEach((shareName) => {
+      const shared = this.options.shared[shareName];
+      if (shared.scope.includes(shareScopeName)) {
+        register(shareName, shared);
+      }
+    });
     if (strategy === 'version-first') {
-      Object.keys(this.options.shared).forEach((shareName) => {
-        const shared = this.options.shared[shareName];
-        if (shared.scope.includes(shareScopeName)) {
-          register(shareName, shared);
-        }
-      });
-
       this.options.remotes.forEach((remote) => {
         if (remote.shareScope === shareScopeName) {
           promises.push(initRemoteModule(remote.name));

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -671,7 +671,8 @@ export class FederationHost {
       );
       if (
         !activeVersion ||
-        (!activeVersion.loaded &&
+        (activeVersion.strategy !== 'loaded-first' &&
+          !activeVersion.loaded &&
           (Boolean(!eager) !== !activeVersionEager
             ? eager
             : hostName > activeVersion.from))

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -671,8 +671,7 @@ export class FederationHost {
       );
       if (
         !activeVersion ||
-        (!activeVersion.loading &&
-          !activeVersion.loaded &&
+        (!activeVersion.loaded &&
           (Boolean(!eager) !== !activeVersionEager
             ? eager
             : hostName > activeVersion.from))

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -650,7 +650,7 @@ export class FederationHost {
   // eslint-disable-next-line @typescript-eslint/member-ordering
   initializeSharing(
     shareScopeName = DEFAULT_SCOPE,
-    strategy?: Shared['strategy'],
+    strategy: Shared['strategy'] = 'version-first',
   ): Array<Promise<void>> {
     const shareScope = this.shareScopeMap;
     const hostName = this.options.name;
@@ -693,14 +693,15 @@ export class FederationHost {
         }
       }
     };
-    Object.keys(this.options.shared).forEach((shareName) => {
-      const shared = this.options.shared[shareName];
-      if (shared.scope.includes(shareScopeName)) {
-        register(shareName, shared);
-      }
-    });
 
     if (strategy === 'version-first') {
+      Object.keys(this.options.shared).forEach((shareName) => {
+        const shared = this.options.shared[shareName];
+        if (shared.scope.includes(shareScopeName)) {
+          register(shareName, shared);
+        }
+      });
+
       this.options.remotes.forEach((remote) => {
         if (remote.shareScope === shareScopeName) {
           promises.push(initRemoteModule(remote.name));

--- a/packages/runtime/src/module/index.ts
+++ b/packages/runtime/src/module/index.ts
@@ -91,7 +91,7 @@ class Module {
           origin: this.host,
         });
 
-      remoteEntryExports.init(
+      await remoteEntryExports.init(
         initContainerOptions.shareScope,
         initContainerOptions.initScope,
         initContainerOptions.remoteEntryInitOptions,

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -130,5 +130,5 @@ export type RemoteEntryExports = {
     shareScope: ShareScopeMap[string],
     initScope?: InitScope,
     remoteEntryInitOPtions?: RemoteEntryInitOptions,
-  ) => void;
+  ) => void | Promise<void>;
 };


### PR DESCRIPTION
fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first'

## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
