### PR TITLE
Release v0.0.11

### DIFF
--- a/.changeset/fresh-baboons-train.md
+++ b/.changeset/fresh-baboons-train.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix(runtime): nativeGlobal is undefined

--- a/.changeset/hip-cars-drop.md
+++ b/.changeset/hip-cars-drop.md
@@ -1,5 +1,0 @@
----
-'@module-federation/runtime': patch
----
-
-fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first'

--- a/.changeset/soft-days-chew.md
+++ b/.changeset/soft-days-chew.md
@@ -1,5 +1,0 @@
----
-'@module-federation/enhanced': patch
----
-
-normalize bundler runtime import paths

--- a/.changeset/weak-baboons-think.md
+++ b/.changeset/weak-baboons-think.md
@@ -1,5 +1,0 @@
----
-'@module-federation/nextjs-mf': patch
----
-
-fix(nextjs-mf): errorLoadRemote hook not to be overridden

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,5 +1,13 @@
 # [0.2.0-canary.5](https://github.com/module-federation/universe/compare/enhanced-0.2.0-canary.4...enhanced-0.2.0-canary.5) (2023-11-20)
 
+## 0.0.11
+
+### Patch Changes
+
+- 5c17bc4: normalize bundler runtime import paths
+  - @module-federation/runtime-tools@0.0.11
+  - @module-federation/sdk@0.0.11
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/enhanced",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "files": [

--- a/packages/nextjs-mf/CHANGELOG.md
+++ b/packages/nextjs-mf/CHANGELOG.md
@@ -1,5 +1,18 @@
 # [8.1.0-canary.7](https://github.com/module-federation/universe/compare/nextjs-mf-8.1.0-canary.6...nextjs-mf-8.1.0-canary.7) (2023-11-21)
 
+## 8.1.8
+
+### Patch Changes
+
+- 845bc52: fix(nextjs-mf): errorLoadRemote hook not to be overridden
+- Updated dependencies [b2ead7a]
+- Updated dependencies [589a3bd]
+- Updated dependencies [5c17bc4]
+  - @module-federation/runtime@0.0.11
+  - @module-federation/enhanced@0.0.11
+  - @module-federation/node@2.0.9
+  - @module-federation/sdk@0.0.11
+
 ## 8.1.7
 
 ### Patch Changes

--- a/packages/nextjs-mf/package.json
+++ b/packages/nextjs-mf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/nextjs-mf",
-  "version": "8.1.7",
+  "version": "8.1.8",
   "license": "MIT",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,16 @@
 # [2.1.0-canary.6](https://github.com/module-federation/universe/compare/node-2.1.0-canary.5...node-2.1.0-canary.6) (2023-11-21)
 
+## 2.0.9
+
+### Patch Changes
+
+- Updated dependencies [b2ead7a]
+- Updated dependencies [589a3bd]
+- Updated dependencies [5c17bc4]
+  - @module-federation/runtime@0.0.11
+  - @module-federation/enhanced@0.0.11
+  - @module-federation/sdk@0.0.11
+
 ## 2.0.8
 
 ### Patch Changes

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/node",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/runtime-tools/CHANGELOG.md
+++ b/packages/runtime-tools/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [1.0.1-canary.1](https://github.com/module-federation/universe/compare/runtime-1.0.0...runtime-1.0.1-canary.1) (2023-12-06)
 
+## 0.0.11
+
+### Patch Changes
+
+- Updated dependencies [b2ead7a]
+- Updated dependencies [589a3bd]
+  - @module-federation/runtime@0.0.11
+  - @module-federation/webpack-bundler-runtime@0.0.11
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/runtime-tools/package.json
+++ b/packages/runtime-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime-tools",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "zhanghang <hanric.zhang@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @module-federation/runtime
 
+## 0.0.11
+
+### Patch Changes
+
+- b2ead7a: fix(runtime): nativeGlobal is undefined
+- 589a3bd: fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first'
+  - @module-federation/sdk@0.0.11
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/runtime",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "zhouxiao <codingzx@gmail.com>",
   "main": "./dist/index.cjs",
   "module": "./dist/index.esm.js",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [1.1.0-canary.1](https://github.com/module-federation/universe/compare/sdk-1.0.0...sdk-1.1.0-canary.1) (2023-12-05)
 
+## 0.0.11
+
 ## 0.0.10
 
 ## 0.0.9

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@module-federation/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "A sdk for support module federation",
   "keywords": [

--- a/packages/webpack-bundler-runtime/CHANGELOG.md
+++ b/packages/webpack-bundler-runtime/CHANGELOG.md
@@ -1,5 +1,14 @@
 # [1.0.0-canary.3](https://github.com/module-federation/universe/compare/webpack-bundler-runtime-1.0.0-canary.2...webpack-bundler-runtime-1.0.0-canary.3) (2023-11-23)
 
+## 0.0.11
+
+### Patch Changes
+
+- Updated dependencies [b2ead7a]
+- Updated dependencies [589a3bd]
+  - @module-federation/runtime@0.0.11
+  - @module-federation/sdk@0.0.11
+
 ## 0.0.10
 
 ### Patch Changes

--- a/packages/webpack-bundler-runtime/package.json
+++ b/packages/webpack-bundler-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "public": true,
   "name": "@module-federation/webpack-bundler-runtime",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "description": "Module Federation Runtime for webpack",
   "keywords": [


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.0.11 -->

## What's Changed
### Bug Fixes 🐞
* fix(runtime): support restricted unsafe-eval environments by @ScriptedAlchemy in https://github.com/module-federation/universe/pull/2018
* fix(3000-home): add trailing slash on antd and lodash shared config by @ryok90 in https://github.com/module-federation/universe/pull/2038
* fix(nextjs-mf): change runtimePlugin definition order  by @ryok90 in https://github.com/module-federation/universe/pull/2052
* fix: normalize bundler runtime import paths by @jonthomp in https://github.com/module-federation/universe/pull/1997
* fix(runtime): nativeGlobal is undefined by @2heal1 in https://github.com/module-federation/universe/pull/2058
* fix(runtime): runtime should not pre-register shared while strategy is 'loaded-first' by @2heal1 in https://github.com/module-federation/universe/pull/2056
### Other Changes
* Release v0.0.10 by @zhoushaw in https://github.com/module-federation/universe/pull/2005
* Update README.md by @Corepex in https://github.com/module-federation/universe/pull/2014
* workflow: add issue labeled by @zhoushaw in https://github.com/module-federation/universe/pull/2028

## New Contributors
* @Corepex made their first contribution in https://github.com/module-federation/universe/pull/2014
* @ryok90 made their first contribution in https://github.com/module-federation/universe/pull/2038
* @jonthomp made their first contribution in https://github.com/module-federation/universe/pull/1997

**Full Changelog**: https://github.com/module-federation/universe/compare/v0.0.10...v0.0.11