### PR TITLE
fix(enhanced): use upath to against more edge cases between different OS

### DIFF
--- a/.changeset/silent-lions-impress.md
+++ b/.changeset/silent-lions-impress.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+fix(enhanced): use upath to against more edge cases between different OS

--- a/packages/enhanced/package.json
+++ b/packages/enhanced/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@module-federation/sdk": "workspace:*",
-    "@module-federation/runtime-tools": "workspace:*"
+    "@module-federation/runtime-tools": "workspace:*",
+    "upath": "2.0.1"
   }
 }

--- a/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
+++ b/packages/enhanced/src/lib/container/runtime/FederationRuntimePlugin.ts
@@ -6,6 +6,7 @@ import {
   normalizeRuntimeInitOptionsWithOutShared,
   modifyEntry,
   createHash,
+  normalizeToPosixPath,
 } from './utils';
 import fs from 'fs';
 import path from 'path';
@@ -46,9 +47,9 @@ class FederationRuntimePlugin {
 
   static getTemplate(runtimePlugins: string[], bundlerRuntimePath?: string) {
     // internal runtime plugin
-    const normalizedBundlerRuntimePath = (
-      bundlerRuntimePath || BundlerRuntimePath
-    ).replaceAll('\\', '/');
+    const normalizedBundlerRuntimePath = normalizeToPosixPath(
+      bundlerRuntimePath || BundlerRuntimePath,
+    );
 
     let runtimePluginTemplates = '';
     const runtimePLuginNames: string[] = [];
@@ -56,11 +57,11 @@ class FederationRuntimePlugin {
     if (Array.isArray(runtimePlugins)) {
       runtimePlugins.forEach((runtimePlugin, index) => {
         const runtimePluginName = `plugin_${index}`;
-        const runtimePluginPath = (
+        const runtimePluginPath = normalizeToPosixPath(
           path.isAbsolute(runtimePlugin)
             ? runtimePlugin
-            : path.join(process.cwd(), runtimePlugin)
-        ).replaceAll('\\', '/');
+            : path.join(process.cwd(), runtimePlugin),
+        );
 
         runtimePluginTemplates += `import ${runtimePluginName} from '${runtimePluginPath}';\n`;
         runtimePLuginNames.push(runtimePluginName);

--- a/packages/enhanced/src/lib/container/runtime/utils.ts
+++ b/packages/enhanced/src/lib/container/runtime/utils.ts
@@ -1,4 +1,6 @@
 import { normalizeWebpackPath } from '@module-federation/sdk/normalize-webpack-path';
+import upath from 'upath';
+import path from 'path';
 import crypto from 'crypto';
 import { parseOptions } from '../options';
 import type { init } from '@module-federation/runtime-tools';
@@ -102,3 +104,6 @@ export function modifyEntry(options: ModifyEntryOptions): void {
 export function createHash(contents: string): string {
   return crypto.createHash('md5').update(contents).digest('hex');
 }
+
+export const normalizeToPosixPath = (p: string) =>
+  upath.normalizeSafe(path.normalize(p || ''));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       '@module-federation/sdk':
         specifier: workspace:*
         version: link:../sdk
+      upath:
+        specifier: 2.0.1
+        version: 2.0.1
       webpack:
         specifier: ^5.0.0
         version: 5.88.2(@swc/core@1.3.102)(esbuild@0.20.0)
@@ -28112,6 +28115,11 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /upath@2.0.1:
+    resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
+    engines: {node: '>=4'}
+    dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.22.2):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}


### PR DESCRIPTION
## Description

* use upath to against more edge cases between different OS

`str.replaceAll` will throw error while node version below 15

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
