### PR TITLE
fix(runtime): use link to preload js assets

### DIFF
--- a/.changeset/forty-dolls-dance.md
+++ b/.changeset/forty-dolls-dance.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/runtime': patch
+'@module-federation/sdk': patch
+---
+
+fix(runtime): use link to preload js

--- a/packages/runtime/__tests__/__snapshots__/preload-remote.spec.ts.snap
+++ b/packages/runtime/__tests__/__snapshots__/preload-remote.spec.ts.snap
@@ -4,7 +4,18 @@ exports[`preload-remote inBrowser > 1 preload with default config 1`] = `
 {
   "links": [
     {
+      "href": "http://localhost:1111/resources/preload/preload-resource/button.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub1-button/button.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
       "href": "http://localhost:1111/resources/preload/preload-resource/button.sync.css",
+      "rel": "preload",
       "type": "style",
     },
   ],
@@ -17,14 +28,6 @@ exports[`preload-remote inBrowser > 1 preload with default config 1`] = `
       "crossorigin": "",
       "src": "http://localhost:1111/resources/preload/preload-resource/sub1-button/federation-remote-entry.js",
     },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/button.sync.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub1-button/button.sync.js",
-    },
   ],
 }
 `;
@@ -33,11 +36,43 @@ exports[`preload-remote inBrowser > 2 preload with all config  1`] = `
 {
   "links": [
     {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2/button.async.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2/button.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2-button/button.async.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2-button/button.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2-add/add.async.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub2-add/add.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+    {
       "href": "http://localhost:1111/resources/preload/preload-resource/sub2/button.async.css",
+      "rel": "preload",
       "type": "style",
     },
     {
       "href": "http://localhost:1111/resources/preload/preload-resource/sub2/button.sync.css",
+      "rel": "preload",
       "type": "style",
     },
   ],
@@ -50,45 +85,23 @@ exports[`preload-remote inBrowser > 2 preload with all config  1`] = `
       "crossorigin": "",
       "src": "http://localhost:1111/resources/preload/preload-resource/sub2-button/federation-remote-entry.js",
     },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2/button.async.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2/button.sync.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2-button/button.async.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2-button/button.sync.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2-add/add.async.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub2-add/add.sync.js",
-    },
   ],
 }
 `;
 
 exports[`preload-remote inBrowser > 3 preload with expose config  1`] = `
 {
-  "links": [],
+  "links": [
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub3/add.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+  ],
   "scripts": [
     {
       "crossorigin": "",
       "src": "http://localhost:1111/resources/preload/preload-resource/sub3/federation-remote-entry.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub3/add.sync.js",
     },
   ],
 }
@@ -96,15 +109,17 @@ exports[`preload-remote inBrowser > 3 preload with expose config  1`] = `
 
 exports[`preload-remote inBrowser > 3 preload with expose config  2`] = `
 {
-  "links": [],
+  "links": [
+    {
+      "href": "http://localhost:1111/resources/preload/preload-resource/sub3/add.sync.js",
+      "rel": "preload",
+      "type": "script",
+    },
+  ],
   "scripts": [
     {
       "crossorigin": "",
       "src": "http://localhost:1111/resources/preload/preload-resource/sub3/federation-remote-entry.js",
-    },
-    {
-      "crossorigin": "",
-      "src": "http://localhost:1111/resources/preload/preload-resource/sub3/add.sync.js",
     },
   ],
 }

--- a/packages/runtime/__tests__/preload-remote.spec.ts
+++ b/packages/runtime/__tests__/preload-remote.spec.ts
@@ -17,6 +17,7 @@ function getLinkInfos(): Array<LinkInfo> {
   const linkInfos: Array<LinkInfo> = [...links].map((link) => ({
     type: link.getAttribute('as') || '',
     href: link.getAttribute('href') || '',
+    rel: link.getAttribute('rel') || '',
   }));
   return linkInfos;
 }

--- a/packages/runtime/src/core.ts
+++ b/packages/runtime/src/core.ts
@@ -204,6 +204,14 @@ export class FederationHost {
       ],
       HTMLScriptElement | void
     >(),
+    createLink: new SyncHook<
+      [
+        {
+          url: string;
+        },
+      ],
+      HTMLLinkElement | void
+    >(),
     // only work for manifest , so not open to the public yet
     fetch: new AsyncHook<
       [string, RequestInit],

--- a/packages/runtime/src/utils/preload.ts
+++ b/packages/runtime/src/utils/preload.ts
@@ -138,7 +138,7 @@ export function preloadAssets(
         },
         {
           rel: 'preload',
-          as: 'style',
+          as: 'script',
         },
         (url: string) => {
           const res = host.loaderHook.lifecycle.createLink.emit({


### PR DESCRIPTION
## Description

* use link to preload js assets
* add createLink hook

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
