### PR TITLE
fix: native federation behaviour on vite

### DIFF
--- a/.changeset/giant-pears-admire.md
+++ b/.changeset/giant-pears-admire.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/native-federation-typescript': patch
+'@module-federation/native-federation-tests': patch
+---
+
+fix: behaviour during vite dev mode

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "tsup": "7.2.0",
     "typedoc": "0.25.8",
     "undici": "5.28.3",
-    "unplugin": "1.6.0"
+    "unplugin": "1.7.1"
   },
   "devDependencies": {
     "@antora/cli": "3.1.5",

--- a/packages/native-federation-tests/package.json
+++ b/packages/native-federation-tests/package.json
@@ -54,9 +54,9 @@
   "dependencies": {
     "adm-zip": "^0.5.10",
     "ansi-colors": "^4.1.3",
-    "axios": "^1.3.4",
-    "rambda": "^7.5.0",
+    "axios": "^1.6.7",
+    "rambda": "^9.1.0",
     "tsup": "^7.0.0",
-    "unplugin": "^1.3.1"
+    "unplugin": "^1.7.1"
   }
 }

--- a/packages/native-federation-tests/src/index.test.ts
+++ b/packages/native-federation-tests/src/index.test.ts
@@ -95,6 +95,49 @@ describe('index', () => {
         },
       });
     });
+
+    it('correctly enrich rspack config', async () => {
+      const options = {
+        moduleFederationConfig: {
+          name: 'moduleFederationTypescript',
+          filename: 'remoteEntry.js',
+          exposes: {
+            './index': exposedIndex,
+          },
+          shared: {
+            react: { singleton: true, eager: true },
+            'react-dom': { singleton: true, eager: true },
+          },
+        },
+        deleteTestsFolder: false,
+        testsFolder: '@mf-tests',
+      };
+
+      const rspackCompiler = {
+        options: {
+          devServer: {
+            foo: {},
+          },
+        },
+      } as any;
+
+      const unplugin = NativeFederationTestsRemote.rollup(
+        options,
+      ) as UnpluginOptions;
+
+      unplugin.rspack?.(rspackCompiler);
+
+      expect(rspackCompiler).toStrictEqual({
+        options: {
+          devServer: {
+            foo: {},
+            static: {
+              directory: resolve('./dist'),
+            },
+          },
+        },
+      });
+    });
   });
 
   describe('NativeFederationTestsHost', () => {

--- a/packages/native-federation-typescript/package.json
+++ b/packages/native-federation-typescript/package.json
@@ -55,8 +55,8 @@
     "adm-zip": "^0.5.10",
     "ansi-colors": "^4.1.3",
     "axios": "^1.6.7",
-    "rambda": "^9.0.1",
-    "unplugin": "^1.6.0"
+    "rambda": "^9.1.0",
+    "unplugin": "^1.7.1"
   },
   "peerDependencies": {
     "typescript": "^4.9.0 || ^5.0.0",

--- a/packages/native-federation-typescript/src/index.test.ts
+++ b/packages/native-federation-typescript/src/index.test.ts
@@ -6,11 +6,11 @@ import { join, resolve } from 'path';
 import { UnpluginOptions } from 'unplugin';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { Compiler } from 'webpack';
 import {
   NativeFederationTypeScriptHost,
   NativeFederationTypeScriptRemote,
 } from './index';
-import type { Compiler } from 'webpack';
 
 describe('index', () => {
   const projectRoot = join(__dirname, '..', '..', '..');
@@ -115,6 +115,49 @@ describe('index', () => {
       await unplugin.webpack?.(webpackCompiler);
 
       expect(webpackCompiler).toStrictEqual({
+        options: {
+          devServer: {
+            foo: {},
+            static: {
+              directory: resolve('./dist'),
+            },
+          },
+        },
+      });
+    });
+
+    it('correctly enrich rspack config', async () => {
+      const options = {
+        moduleFederationConfig: {
+          name: 'moduleFederationTypescript',
+          filename: 'remoteEntry.js',
+          exposes: {
+            './index': join(__dirname, './index.ts'),
+          },
+          shared: {
+            react: { singleton: true, eager: true },
+            'react-dom': { singleton: true, eager: true },
+          },
+        },
+        deleteTestsFolder: false,
+        testsFolder: '@mf-tests',
+      };
+
+      const rspackCompiler = {
+        options: {
+          devServer: {
+            foo: {},
+          },
+        },
+      } as any;
+
+      const unplugin = NativeFederationTypeScriptRemote.rollup(
+        options,
+      ) as UnpluginOptions;
+
+      unplugin.rspack?.(rspackCompiler);
+
+      expect(rspackCompiler).toStrictEqual({
         options: {
           devServer: {
             foo: {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 5.28.3
         version: 5.28.3
       unplugin:
-        specifier: 1.6.0
-        version: 1.6.0
+        specifier: 1.7.1
+        version: 1.7.1
     devDependencies:
       '@antora/cli':
         specifier: 3.1.5
@@ -1025,17 +1025,17 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3
       axios:
-        specifier: ^1.3.4
-        version: 1.6.0
+        specifier: ^1.6.7
+        version: 1.6.7
       rambda:
-        specifier: ^7.5.0
-        version: 7.5.0
+        specifier: ^9.1.0
+        version: 9.1.0
       tsup:
         specifier: ^7.0.0
         version: 7.2.0(@swc/core@1.3.102)(postcss@8.4.35)(ts-node@10.9.1)(typescript@5.3.3)
       unplugin:
-        specifier: ^1.3.1
-        version: 1.5.1
+        specifier: ^1.7.1
+        version: 1.7.1
 
   packages/native-federation-typescript:
     dependencies:
@@ -1049,14 +1049,14 @@ importers:
         specifier: ^1.6.7
         version: 1.6.7
       rambda:
-        specifier: ^9.0.1
-        version: 9.0.1
+        specifier: ^9.1.0
+        version: 9.1.0
       typescript:
         specifier: ^4.9.0 || ^5.0.0
         version: 5.1.6
       unplugin:
-        specifier: ^1.6.0
-        version: 1.6.0
+        specifier: ^1.7.1
+        version: 1.7.1
       vue-tsc:
         specifier: ^1.0.24
         version: 1.8.22(typescript@5.1.6)
@@ -9696,7 +9696,7 @@ packages:
     dependencies:
       '@rsbuild/core': 0.3.4
       '@rsbuild/shared': 0.3.4(@swc/helpers@0.5.3)
-      acorn: 8.11.2
+      acorn: 8.11.3
       caniuse-lite: 1.0.30001579
       htmlparser2: 9.0.0
       source-map: 0.7.4
@@ -11103,7 +11103,7 @@ packages:
     resolution: {integrity: sha512-xTHv9BUh3bkDVCvcbmdfVF0/e96BdrEgqPJ3G3RmKbSzWLOkQ2U9yiPfHzT0KJWPhVwj12fjfZp0zunu+pcS6Q==}
     dependencies:
       '@storybook/csf-tools': 7.6.17
-      unplugin: 1.6.0
+      unplugin: 1.7.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -13573,7 +13573,7 @@ packages:
   /acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
     dev: true
 
@@ -13592,12 +13592,12 @@ packages:
       acorn: 7.4.1
     dev: true
 
-  /acorn-jsx@5.3.2(acorn@8.11.2):
+  /acorn-jsx@5.3.2(acorn@8.11.3):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
     dev: true
 
   /acorn-walk@7.2.0:
@@ -13622,6 +13622,11 @@ packages:
 
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -14359,16 +14364,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
-
-  /axios@1.6.0:
-    resolution: {integrity: sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==}
-    dependencies:
-      follow-redirects: 1.15.3
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /axios@1.6.7:
     resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
@@ -18522,8 +18517,8 @@ packages:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -19257,16 +19252,6 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
     dev: true
-
-  /follow-redirects@1.15.3:
-    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
 
   /follow-redirects@1.15.4:
     resolution: {integrity: sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==}
@@ -22157,7 +22142,7 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-globals: 7.0.1
       cssom: 0.5.0
       cssstyle: 2.3.0
@@ -23440,8 +23425,8 @@ packages:
   /micromark-extension-mdxjs@1.0.1:
     resolution: {integrity: sha512-7YA7hF6i5eKOfFUzZ+0z6avRG52GpWR8DL+kN47y3f2KhxbBZMhmxe7auOeaTBrW2DenbbZTf1ea9tA2hDpC2Q==}
     dependencies:
-      acorn: 8.11.2
-      acorn-jsx: 5.3.2(acorn@8.11.2)
+      acorn: 8.11.3
+      acorn-jsx: 5.3.2(acorn@8.11.3)
       micromark-extension-mdx-expression: 1.0.8
       micromark-extension-mdx-jsx: 1.0.5
       micromark-extension-mdx-md: 1.0.1
@@ -23923,7 +23908,7 @@ packages:
   /mlly@1.4.2:
     resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
       pathe: 1.1.1
       pkg-types: 1.0.3
       ufo: 1.3.2
@@ -27032,8 +27017,8 @@ packages:
     resolution: {integrity: sha512-y/M9weqWAH4iopRd7EHDEQQvpFPHj1AA3oHozE9tfITHUtTR7Z9PSlIRRG2l1GuW7sefC1cXFfIcF+cgnShdBA==}
     dev: false
 
-  /rambda@9.0.1:
-    resolution: {integrity: sha512-Su5spknJIBhYUDHNyfEYknOmZTHxbT+kOGRuzLtxF+gjI7YBm7lX0DE/7qnQ6zszve62AJFuLC+7gXD/VSiwRQ==}
+  /rambda@9.1.0:
+    resolution: {integrity: sha512-fCRAq8Of+bAuqjAA0MSb/umbNgiYwy9N5camM2T++Qu/mRImLT3a31hf0REvnqaWCrgrdC3ewf/ucAILsYeBgQ==}
     dev: false
 
   /ramda@0.28.0:
@@ -29736,7 +29721,7 @@ packages:
   /strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
     dev: true
 
   /strip-outer@2.0.0:
@@ -30370,7 +30355,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
@@ -30382,7 +30367,7 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.5
-      acorn: 8.11.2
+      acorn: 8.11.3
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: true
@@ -30797,7 +30782,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 16.11.68
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -30829,7 +30814,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 16.11.68
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -30861,7 +30846,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.19.18
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -30893,7 +30878,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.19.18
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -30925,7 +30910,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.19.18
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -30956,7 +30941,7 @@ packages:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.5.1
-      acorn: 8.11.2
+      acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3
       create-require: 1.1.1
@@ -31524,19 +31509,10 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  /unplugin@1.5.1:
-    resolution: {integrity: sha512-0QkvG13z6RD+1L1FoibQqnvTwVBXvS4XSPwAyinVgoOCl2jAgwzdUKmEj05o4Lt8xwQI85Hb6mSyYkcAGwZPew==}
+  /unplugin@1.7.1:
+    resolution: {integrity: sha512-JqzORDAPxxs8ErLV4x+LL7bk5pk3YlcWqpSNsIkAZj972KzFZLClc/ekppahKkOczGkwIG6ElFgdOgOlK4tXZw==}
     dependencies:
-      acorn: 8.11.2
-      chokidar: 3.5.3
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.6.1
-    dev: false
-
-  /unplugin@1.6.0:
-    resolution: {integrity: sha512-BfJEpWBu3aE/AyHx8VaNE/WgouoQxgH9baAiH82JjX8cqVyi3uJQstqwD5J+SZxIK326SZIhsSZlALXVBCknTQ==}
-    dependencies:
-      acorn: 8.11.2
+      acorn: 8.11.3
       chokidar: 3.5.3
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.6.1


### PR DESCRIPTION
## Description

During vite dev mode, `writeBundle` hook is not invoked.
Said so, types and tests are not re-generated while developing

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
