### PR TITLE
fix(runtime): preserve error.stack instead of throwing new error

### DIFF
--- a/.changeset/warm-berries-serve.md
+++ b/.changeset/warm-berries-serve.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix(runtime): preserve error.stack instead of throwing new error

--- a/packages/runtime/src/utils/logger.ts
+++ b/packages/runtime/src/utils/logger.ts
@@ -8,9 +8,18 @@ export function assert(condition: any, msg: string): asserts condition {
 }
 
 export function error(msg: string | Error | unknown): never {
+  if (msg instanceof Error) {
+    msg.message = `${LOG_CATEGORY}: ${msg.message}`;
+    throw msg;
+  }
   throw new Error(`${LOG_CATEGORY}: ${msg}`);
 }
 
 export function warn(msg: Parameters<typeof console.warn>[0]): void {
-  console.warn(`${LOG_CATEGORY}: ${msg}`);
+  if (msg instanceof Error) {
+    msg.message = `${LOG_CATEGORY}: ${msg.message}`;
+    console.warn(msg);
+  } else {
+    console.warn(`${LOG_CATEGORY}: ${msg}`);
+  }
 }


### PR DESCRIPTION
## Description

preserve error.stack instead of throwing new error

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
