### PR TITLE
feat(runtime): add headers from env variable while requesting manifest

### DIFF
--- a/.changeset/healthy-camels-sniff.md
+++ b/.changeset/healthy-camels-sniff.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/sdk': patch
+---
+
+feat(sdk): add genHeaders util
+feat(runtime): add headers from env variable while requesting manifest

--- a/packages/runtime/src/plugins/snapshot/SnapshotHandler.ts
+++ b/packages/runtime/src/plugins/snapshot/SnapshotHandler.ts
@@ -4,6 +4,7 @@ import {
   ModuleInfo,
   generateSnapshotFromManifest,
   isManifestProvider,
+  getHeaders,
 } from '@module-federation/sdk';
 import { Optional, Options, Remote } from '../../type';
 import { isRemoteInfoWithEntry, error } from '../../utils';
@@ -269,9 +270,12 @@ export class SnapshotHandler {
         return manifestJson;
       }
       try {
-        let res = await this.loaderHook.lifecycle.fetch.emit(manifestUrl, {});
+        const headers = getHeaders();
+        let res = await this.loaderHook.lifecycle.fetch.emit(manifestUrl, {
+          headers,
+        });
         if (!res || !(res instanceof Response)) {
-          res = await fetch(manifestUrl, {});
+          res = await fetch(manifestUrl, { headers });
         }
         manifestJson = (await res.json()) as Manifest;
         assert(

--- a/packages/sdk/__tests__/getHeaders.spec.ts
+++ b/packages/sdk/__tests__/getHeaders.spec.ts
@@ -1,0 +1,35 @@
+import { getHeaders, HEADERS_KEY } from '../src';
+
+describe('getHeaders', () => {
+  const headers = {
+    'custom-header-1': 'custom_header_value_1',
+    'custom-header-2': 'custom_header_value_2',
+  };
+  const headersStr = JSON.stringify(headers);
+
+  it('get headers empty object by default', () => {
+    expect(getHeaders()).toEqual({});
+  });
+
+  it('get headers values by setting FEDERATION_HEADERS variable', () => {
+    const prevWindow = window;
+    // @ts-ignore
+    delete global.window;
+    process.env[HEADERS_KEY] = headersStr;
+    expect(getHeaders()).toEqual(headers);
+    delete process.env[HEADERS_KEY];
+    global.window = prevWindow;
+  });
+
+  it(`get headers while set localStorage.${HEADERS_KEY}`, () => {
+    global.window.localStorage.setItem(HEADERS_KEY, headersStr);
+    expect(getHeaders()).toEqual(headers);
+    global.window.localStorage.removeItem(HEADERS_KEY);
+  });
+
+  it('get headers empty object while not set localStorage.HEADERS_KEY', () => {
+    global.window.localStorage.setItem(HEADERS_KEY, '{}');
+    expect(getHeaders()).toEqual({});
+    global.window.localStorage.removeItem(HEADERS_KEY);
+  });
+});

--- a/packages/sdk/src/constant.ts
+++ b/packages/sdk/src/constant.ts
@@ -30,3 +30,5 @@ export const MFModuleType = {
   NPM: 'npm',
   APP: 'app',
 };
+
+export const HEADERS_KEY = 'FEDERATION_HEADERS';

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -5,6 +5,7 @@ import {
   EncodedNameTransformMap,
   SEPARATOR,
   MANIFEST_EXT,
+  HEADERS_KEY,
 } from './constant';
 import { Logger } from './logger';
 import { getProcessEnv } from './env';
@@ -205,7 +206,19 @@ const warn = (msg: Parameters<typeof console.warn>[0]): void => {
   console.warn(`${LOG_CATEGORY}: ${msg}`);
 };
 
+const getHeaders = (): Record<string, string> => {
+  if (typeof window !== 'undefined') {
+    return JSON.parse(localStorage.getItem(HEADERS_KEY) || '{}');
+  }
+  const headersStr = getProcessEnv()[HEADERS_KEY] || '{}';
+
+  return {
+    ...JSON.parse(headersStr),
+  };
+};
+
 export {
+  getHeaders,
   parseEntry,
   logger,
   decodeName,


### PR DESCRIPTION
## Description

* feat(sdk): add genHeaders util
* feat(runtime): add headers from env variable while requesting manifest

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
