### PR TITLE
fix(nextjs-mf): only call module factory in valid conditions

### DIFF
--- a/.changeset/fast-games-report.md
+++ b/.changeset/fast-games-report.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': patch
+---
+
+only call module factory in valid conditions in runtime plugin

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -73,10 +73,11 @@ export default function (): FederationRuntimePlugin {
     onLoad(args) {
       const { exposeModuleFactory, exposeModule, id } = args;
       const moduleOrFactory = exposeModuleFactory || exposeModule;
-      if (!moduleOrFactory) return; // Ensure moduleOrFactory is defined
-      let exposedModuleExports: any = moduleOrFactory();
+      if (!moduleOrFactory) return args; // Ensure moduleOrFactory is defined
 
       if (typeof window === 'undefined') {
+        let exposedModuleExports: any = moduleOrFactory();
+
         const handler: ProxyHandler<any> = {
           get(target, prop, receiver) {
             // Check if accessing a static property of the function itself


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Runtime plugin causes false failure when returning static exports object
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
