### PR TITLE
fix(nextjs-mf): throw compile error if AppDir is used

### DIFF
--- a/.changeset/metal-kangaroos-drop.md
+++ b/.changeset/metal-kangaroos-drop.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': patch
+---
+
+Prevent application from compiling if AppDir is used at all

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -80,6 +80,19 @@ export class NextFederationPlugin {
   }
 
   private validateOptions(compiler: Compiler): boolean {
+    const manifestPlugin = compiler.options.plugins.find(
+      (p) => p?.constructor.name === 'BuildManifestPlugin',
+    );
+
+    if (manifestPlugin) {
+      //@ts-ignore
+      if (manifestPlugin?.appDirEnabled) {
+        throw new Error(
+          'App Directory is not supported by nextjs-mf. Use only pages directory, do not open git issues about this',
+        );
+      }
+    }
+
     const compilerValid = validateCompilerOptions(compiler);
     const pluginValid = validatePluginOptions(this._options);
     const envValid = process.env['NEXT_PRIVATE_LOCAL_WEBPACK'];
@@ -109,6 +122,7 @@ export class NextFederationPlugin {
     if (this._extraOptions.debug) {
       compiler.options.devtool = false;
     }
+
     if (isServer) {
       configureServerCompilerOptions(compiler);
       configureServerLibraryAndFilename(this._options);


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Break compilation when app Directory is detected
<!--- Describe your changes in detail -->
Since Nextjs mf cannot support app directory, prevent compilation altogether if used

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
