### PR TITLE
fix(nextjs-mf): cache bust remote urls

### DIFF
--- a/.changeset/thick-birds-clap.md
+++ b/.changeset/thick-birds-clap.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': patch
+---
+
+cache bust remote entry

--- a/apps/3001-shop/pages/shop/index.tsx
+++ b/apps/3001-shop/pages/shop/index.tsx
@@ -49,7 +49,7 @@ Shop.getInitialProps = async () => {
   const timeout = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
-  const fetchPromise = fetch('https://swapi.dev/api/people/1')
+  const fetchPromise = fetch('http://swapi.dev/api/planets/1/')
     .then((res) => res.json())
     .catch((err) => {
       if (err instanceof Error) {

--- a/apps/3002-checkout/pages/checkout/index.tsx
+++ b/apps/3002-checkout/pages/checkout/index.tsx
@@ -47,9 +47,9 @@ Checkout.getInitialProps = async () => {
   const timeout = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
-  const fetchPromise = fetch(
-    'https://jsonplaceholder.typicode.com/todos/1',
-  ).then((res) => res.json());
+  const fetchPromise = fetch('http://swapi.dev/api/planets/1/').then((res) =>
+    res.json(),
+  );
 
   // this will resolve after 3 seconds
   const timerPromise = timeout(3000).then(() => ({

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -88,7 +88,12 @@ export default function (): FederationRuntimePlugin {
       if (!moduleOrFactory) return args; // Ensure moduleOrFactory is defined
 
       if (typeof window === 'undefined') {
-        let exposedModuleExports: any = moduleOrFactory();
+        let exposedModuleExports: any;
+        try {
+          exposedModuleExports = moduleOrFactory();
+        } catch (e) {
+          exposedModuleExports = moduleOrFactory;
+        }
 
         const handler: ProxyHandler<any> = {
           get(target, prop, receiver) {
@@ -142,12 +147,13 @@ export default function (): FederationRuntimePlugin {
               );
             }
           });
+          return () => exposedModuleExports;
         } else {
           // For objects, just wrap the exported object itself
           exposedModuleExports = new Proxy(exposedModuleExports, handler);
         }
 
-        return () => exposedModuleExports;
+        return exposedModuleExports;
       }
 
       return args;

--- a/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
+++ b/packages/nextjs-mf/src/plugins/container/runtimePlugin.ts
@@ -61,7 +61,19 @@ export default function (): FederationRuntimePlugin {
     init(args) {
       return args;
     },
-    beforeRequest(args) {
+    beforeRequest: (args) => {
+      const { options, id } = args;
+      const remoteName = id.split('/').shift();
+      const remote = options.remotes.find(
+        (remote) => remote.name === remoteName,
+      );
+      if (!remote) return args;
+      //@ts-ignore
+      if (remote?.entry?.includes('?t=')) {
+        return args;
+      }
+      //@ts-ignore
+      remote.entry = `${remote?.entry}?t=${Date.now()}`;
       return args;
     },
     createScript({ url }) {


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
automatically cache bust remote entry injection
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/module-federation/universe/issues/2208

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
