### PR TITLE
refactor(enhanced): no additional entry dependency

### DIFF
--- a/packages/enhanced/src/lib/container/ContainerEntryModule.ts
+++ b/packages/enhanced/src/lib/container/ContainerEntryModule.ts
@@ -185,10 +185,10 @@ class ContainerEntryModule extends Module {
       ) as unknown as Dependency,
     );
 
-    this.addDependency(
-      // @ts-ignore
-      new EntryDependency(this._injectRuntimeEntry),
-    );
+    // this.addDependency(
+    //   // @ts-ignore
+    //   new EntryDependency(this._injectRuntimeEntry),
+    // );
     callback();
   }
 
@@ -255,14 +255,14 @@ class ContainerEntryModule extends Module {
     }
 
     const initRuntimeDep = this.dependencies[1];
-    const initRuntimeModuleGetter = runtimeTemplate.moduleRaw({
-      module: moduleGraph.getModule(initRuntimeDep),
-      chunkGraph,
-      // @ts-expect-error
-      request: initRuntimeDep.userRequest,
-      weak: false,
-      runtimeRequirements,
-    });
+    // const initRuntimeModuleGetter = runtimeTemplate.moduleRaw({
+    //   module: moduleGraph.getModule(initRuntimeDep),
+    //   chunkGraph,
+    //   // @ts-expect-error
+    //   request: initRuntimeDep.userRequest,
+    //   weak: false,
+    //   runtimeRequirements,
+    // });
     const federationGlobal = getFederationGlobalScope(
       RuntimeGlobals || ({} as typeof RuntimeGlobals),
     );
@@ -304,7 +304,7 @@ class ContainerEntryModule extends Module {
           '})',
         ],
       )};`,
-      `${initRuntimeModuleGetter}`,
+      // `${initRuntimeModuleGetter}`,
       '',
       '// This exports getters to disallow modifications',
       `${RuntimeGlobals.definePropertyGetters}(exports, {`,

--- a/packages/enhanced/src/lib/container/ContainerPlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerPlugin.ts
@@ -226,8 +226,6 @@ class ContainerPlugin {
           }
         });
 
-        console.log(runtimes);
-
         // Add container entry for each runtime that exists
         for (const runtime of runtimes) {
           const name = runtime

--- a/packages/enhanced/src/lib/container/ContainerPlugin.ts
+++ b/packages/enhanced/src/lib/container/ContainerPlugin.ts
@@ -168,14 +168,14 @@ class ContainerPlugin {
     }
     const hasSingleRuntimeChunk = compiler.options?.optimization?.runtimeChunk;
 
-    new compiler.webpack.EntryPlugin(
-      compiler.options.context || '',
-      federationRuntimePluginInstance.entryFilePath,
-      {
-        name,
-        runtime: hasSingleRuntimeChunk ? false : runtime,
-      },
-    ).apply(compiler);
+    // new compiler.webpack.EntryPlugin(
+    //   compiler.options.context || '',
+    //   federationRuntimePluginInstance.entryFilePath,
+    //   {
+    //     name,
+    //     runtime: hasSingleRuntimeChunk ? false : runtime,
+    //   },
+    // ).apply(compiler);
 
     compiler.hooks.make.tapAsync(PLUGIN_NAME, (compilation, callback) => {
       const dep = new ContainerEntryDependency(
@@ -226,7 +226,9 @@ class ContainerPlugin {
           }
         });
 
-        //Add container entry for each runtime that exists
+        console.log(runtimes);
+
+        // Add container entry for each runtime that exists
         for (const runtime of runtimes) {
           const name = runtime
             ? 'federation-runtime-' + runtime

--- a/packages/nextjs-mf/README.md
+++ b/packages/nextjs-mf/README.md
@@ -165,12 +165,16 @@ new NextFederationPlugin({
   extraOptions: {
     debug: boolean, // `false` by default
     exposePages: boolean, // `false` by default
+    enableImageLoaderFix: boolean, // `false` by default
+    enableUrlLoaderFix: boolean, // `false` by default
   },
 });
 ```
 
 - `debug` – enables debug mode. It will print additional information about what is going on under the hood.
 - `exposePages` – exposes automatically all nextjs pages for you and theirs `./pages-map`.
+- `enableImageLoaderFix` – adds public hostname to all assets bundled by `nextjs-image-loader`. So if you serve remoteEntry from `http://example.com` then all bundled assets will get this hostname in runtime. It's something like Base URL in HTML but for federated modules.
+- `enableUrlLoaderFix` – adds public hostname to all assets bundled by `url-loader`.
 
 ## Demo
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
remove additional entry module injections into federation, instead it will use the runtime module for eager loading of runtime and plugin entry modules
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
