### PR TITLE
fix(nextjs-mf): skip sharing next internals

### DIFF
--- a/.changeset/quiet-ties-notice.md
+++ b/.changeset/quiet-ties-notice.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/nextjs-mf': major
+---
+
+implement skipSharingNextInternals option again

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -62,14 +62,14 @@ export class NextFederationPlugin {
     this.applyConditionalPlugins(compiler, isServer);
     const normalFederationPluginOptions = this.getNormalFederationPluginOptions(
       compiler,
-      isServer
+      isServer,
     );
     // ContainerPlugin will get NextFederationPlugin._options, so NextFederationPlugin._options should be the same as normalFederationPluginOptions
     this._options = normalFederationPluginOptions;
     new ModuleFederationPlugin(normalFederationPluginOptions).apply(compiler);
 
     const runtimeESMPath = require.resolve(
-      '@module-federation/runtime/dist/index.esm.js'
+      '@module-federation/runtime/dist/index.esm.js',
     );
     compiler.hooks.afterPlugins.tap('PatchAliasWebpackPlugin', () => {
       compiler.options.resolve.alias = {
@@ -81,14 +81,14 @@ export class NextFederationPlugin {
 
   private validateOptions(compiler: Compiler): boolean {
     const manifestPlugin = compiler.options.plugins.find(
-      (p) => p?.constructor.name === 'BuildManifestPlugin'
+      (p) => p?.constructor.name === 'BuildManifestPlugin',
     );
 
     if (manifestPlugin) {
       //@ts-ignore
       if (manifestPlugin?.appDirEnabled) {
         throw new Error(
-          'App Directory is not supported by nextjs-mf. Use only pages directory, do not open git issues about this'
+          'App Directory is not supported by nextjs-mf. Use only pages directory, do not open git issues about this',
         );
       }
     }
@@ -103,7 +103,7 @@ export class NextFederationPlugin {
       compiler.options.name === 'server' || compiler.options.name === 'client';
     if (!envValid)
       throw new Error(
-        'process.env.NEXT_PRIVATE_LOCAL_WEBPACK is not set to true, please set it to true, and "npm install webpack"'
+        'process.env.NEXT_PRIVATE_LOCAL_WEBPACK is not set to true, please set it to true, and "npm install webpack"',
       );
     return (
       compilerValid !== undefined &&
@@ -138,7 +138,7 @@ export class NextFederationPlugin {
 
   private getNormalFederationPluginOptions(
     compiler: Compiler,
-    isServer: boolean
+    isServer: boolean,
   ): ModuleFederationPluginOptions {
     const defaultShared = this._extraOptions.skipSharingNextInternals
       ? {}

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -62,14 +62,14 @@ export class NextFederationPlugin {
     this.applyConditionalPlugins(compiler, isServer);
     const normalFederationPluginOptions = this.getNormalFederationPluginOptions(
       compiler,
-      isServer,
+      isServer
     );
     // ContainerPlugin will get NextFederationPlugin._options, so NextFederationPlugin._options should be the same as normalFederationPluginOptions
     this._options = normalFederationPluginOptions;
     new ModuleFederationPlugin(normalFederationPluginOptions).apply(compiler);
 
     const runtimeESMPath = require.resolve(
-      '@module-federation/runtime/dist/index.esm.js',
+      '@module-federation/runtime/dist/index.esm.js'
     );
     compiler.hooks.afterPlugins.tap('PatchAliasWebpackPlugin', () => {
       compiler.options.resolve.alias = {
@@ -81,14 +81,14 @@ export class NextFederationPlugin {
 
   private validateOptions(compiler: Compiler): boolean {
     const manifestPlugin = compiler.options.plugins.find(
-      (p) => p?.constructor.name === 'BuildManifestPlugin',
+      (p) => p?.constructor.name === 'BuildManifestPlugin'
     );
 
     if (manifestPlugin) {
       //@ts-ignore
       if (manifestPlugin?.appDirEnabled) {
         throw new Error(
-          'App Directory is not supported by nextjs-mf. Use only pages directory, do not open git issues about this',
+          'App Directory is not supported by nextjs-mf. Use only pages directory, do not open git issues about this'
         );
       }
     }
@@ -103,7 +103,7 @@ export class NextFederationPlugin {
       compiler.options.name === 'server' || compiler.options.name === 'client';
     if (!envValid)
       throw new Error(
-        'process.env.NEXT_PRIVATE_LOCAL_WEBPACK is not set to true, please set it to true, and "npm install webpack"',
+        'process.env.NEXT_PRIVATE_LOCAL_WEBPACK is not set to true, please set it to true, and "npm install webpack"'
       );
     return (
       compilerValid !== undefined &&
@@ -138,9 +138,11 @@ export class NextFederationPlugin {
 
   private getNormalFederationPluginOptions(
     compiler: Compiler,
-    isServer: boolean,
+    isServer: boolean
   ): ModuleFederationPluginOptions {
-    const defaultShared = retrieveDefaultShared(isServer);
+    const defaultShared = this._extraOptions.skipSharingNextInternals
+      ? {}
+      : retrieveDefaultShared(isServer);
     const noop = this.getNoopPath();
     return {
       ...this._options,


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Allow next to skip sharing default internals
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
