### PR TITLE
fix(nextjs-mf): skip share next internals

### DIFF
--- a/.changeset/light-tomatoes-camp.md
+++ b/.changeset/light-tomatoes-camp.md
@@ -1,0 +1,6 @@
+---
+'@module-federation/nextjs-mf': patch
+'@module-federation/utilities': patch
+---
+
+no default expose when skip sharing next internals enabled

--- a/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
+++ b/packages/nextjs-mf/src/plugins/NextFederationPlugin/index.ts
@@ -28,12 +28,14 @@ import {
 } from './apply-server-plugins';
 import { applyClientPlugins } from './apply-client-plugins';
 import { ModuleFederationPlugin } from '@module-federation/enhanced';
+import type { moduleFederationPlugin } from '@module-federation/sdk';
+
 import path from 'path';
 /**
  * NextFederationPlugin is a webpack plugin that handles Next.js application federation using Module Federation.
  */
 export class NextFederationPlugin {
-  private _options: ModuleFederationPluginOptions;
+  private _options: moduleFederationPlugin.ModuleFederationPluginOptions;
   private _extraOptions: NextFederationPluginExtraOptions;
   public name: string;
   /**
@@ -140,25 +142,31 @@ export class NextFederationPlugin {
     compiler: Compiler,
     isServer: boolean,
   ): ModuleFederationPluginOptions {
+    console.log(this._extraOptions.skipSharingNextInternals);
     const defaultShared = this._extraOptions.skipSharingNextInternals
       ? {}
       : retrieveDefaultShared(isServer);
     const noop = this.getNoopPath();
+
+    const defaultExpose = this._extraOptions.skipSharingNextInternals
+      ? {}
+      : {
+          './noop': noop,
+          './react': require.resolve('react'),
+          './react-dom': require.resolve('react-dom'),
+          './next/router': require.resolve('next/router'),
+        };
     return {
       ...this._options,
       runtime: false,
       remoteType: 'script',
-      // @ts-ignore
       runtimePlugins: [
         require.resolve(path.join(__dirname, '../container/runtimePlugin')),
-        //@ts-ignore
         ...(this._options.runtimePlugins || []),
       ],
+      //@ts-ignore
       exposes: {
-        './noop': noop,
-        './react': require.resolve('react'),
-        './react-dom': require.resolve('react-dom'),
-        './next/router': require.resolve('next/router'),
+        ...(this._extraOptions.skipSharingNextInternals ? {} : defaultExpose),
         ...this._options.exposes,
         ...(this._extraOptions.exposePages
           ? exposeNextjsPages(compiler.options.context as string)

--- a/packages/utilities/src/types/index.ts
+++ b/packages/utilities/src/types/index.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../../../node_modules/webpack/module.d.ts" />
-import { moduleFederationPlugin } from '@module-federation/sdk';
+import type { moduleFederationPlugin } from '@module-federation/sdk';
 
 import type { container, WebpackOptionsNormalized } from 'webpack';
 


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
disable noop exposes of next modules when skip share is enabled
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
