### PR TITLE
docs: fix devtool doc format error

### DIFF
--- a/apps/website-new/docs/en/guide/basic/chrome-devtool.mdx
+++ b/apps/website-new/docs/en/guide/basic/chrome-devtool.mdx
@@ -1,6 +1,7 @@
 # Chrome DevTools
 
 In implementation 🚧
+
 {/*
 The `Microfrontend` architecture differs from the traditional monolithic application development model. Its characteristics of separate development, deployment, and debugging necessitate a new set of debugging tools to meet new usage scenarios, such as: how to verify the effect of modules in actual projects when developing `Module Federation`, whether the dependencies of `Module Federation` are reused with the host environment, which `Module Federation` modules are loaded on the current page, the dependency relationships of `Module Federation`, and how the data flow between `Module Federation` works.
 
@@ -77,7 +78,7 @@ You can open DevTools in a separate window.
 - ✅ Configuration rules are checked.
 - ✅ Configuration is filled in correctly, the page shows: Proxy configuration is effective, remote module retrieval is successful, the corresponding page has been automatically refreshed.
 
-{/* ![](@public/guide/chrome-devtools/proxy-rule.png) */}
+![](@public/guide/chrome-devtools/proxy-rule.png)
 
 ### Partial Configuration Complies with Rules
 


### PR DESCRIPTION
## Description

* docs: fix devtool doc format error

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

none

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
