### PR TITLE
fix: output error in file

### DIFF
--- a/.changeset/stale-hairs-remain.md
+++ b/.changeset/stale-hairs-remain.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/dts-plugin': patch
+---
+
+fix: output error in file

--- a/apps/react-ts-nested-remote/project.json
+++ b/apps/react-ts-nested-remote/project.json
@@ -60,8 +60,7 @@
       "options": {
         "buildTarget": "react_ts_nested_remote:build",
         "hmr": true,
-        "port": 3005,
-        "host": "0.0.0.0"
+        "port": 3005
       },
       "configurations": {
         "development": {

--- a/apps/runtime-demo/3006-runtime-remote/project.json
+++ b/apps/runtime-demo/3006-runtime-remote/project.json
@@ -49,8 +49,7 @@
       "options": {
         "buildTarget": "3006-runtime-remote:build",
         "hmr": true,
-        "port": 3006,
-        "host": "0.0.0.0"
+        "port": 3006
       },
       "configurations": {
         "development": {

--- a/packages/dts-plugin/src/core/lib/DTSManager.ts
+++ b/packages/dts-plugin/src/core/lib/DTSManager.ts
@@ -23,6 +23,7 @@ import {
 } from '../constant';
 import axios from 'axios';
 import { replaceLocalhost } from './utils';
+import { fileLog } from '../../server';
 
 export const MODULE_DTS_MANAGER_IDENTIFIER = 'MF DTS Manager';
 
@@ -199,7 +200,11 @@ class DTSManager {
       ).href;
       return remoteInfo as Required<RemoteInfo>;
     } catch (_err) {
-      console.error(_err);
+      fileLog(
+        `fetch manifest failed, ${_err}, ${remoteInfo.name} will be ignored`,
+        'requestRemoteManifest',
+        'error',
+      );
       return remoteInfo as Required<RemoteInfo>;
     }
   }
@@ -235,10 +240,10 @@ class DTSManager {
       fs.writeFileSync(filePath, apiTypeFile);
       this.loadedRemoteAPIAlias.push(remoteInfo.alias);
     } catch (err) {
-      console.error(
-        ansiColors.red(
-          `Unable to download "${remoteInfo.name}" api types, ${err}`,
-        ),
+      fileLog(
+        `Unable to download "${remoteInfo.name}" api types, ${err}`,
+        'consumeTargetRemotes',
+        'error',
       );
     }
   }
@@ -297,8 +302,10 @@ class DTSManager {
         recursive: true,
         force: true,
       }).catch((error) =>
-        console.error(
-          ansiColors.red(`Unable to remove types folder, ${error}`),
+        fileLog(
+          `Unable to remove types folder, ${error}`,
+          'consumeArchiveTypes',
+          'error',
         ),
       );
     }
@@ -361,8 +368,10 @@ class DTSManager {
       console.log(ansiColors.green('Federated types extraction completed'));
     } catch (err) {
       if (this.options.host?.abortOnError === false) {
-        console.error(
-          ansiColors.red(`Unable to consume federated types, ${err}`),
+        fileLog(
+          `Unable to consume federated types, ${err}`,
+          'consumeTypes',
+          'error',
         );
       } else {
         throw err;

--- a/packages/dts-plugin/src/core/lib/archiveHandler.ts
+++ b/packages/dts-plugin/src/core/lib/archiveHandler.ts
@@ -1,5 +1,4 @@
 import AdmZip from 'adm-zip';
-import ansiColors from 'ansi-colors';
 import axios from 'axios';
 import { resolve, join } from 'path';
 import typescript from 'typescript';
@@ -7,7 +6,8 @@ import typescript from 'typescript';
 import { HostOptions } from '../interfaces/HostOptions';
 import { RemoteOptions } from '../interfaces/RemoteOptions';
 import { retrieveMfTypesPath } from './typeScriptCompiler';
-import { isDebugMode, replaceLocalhost } from './utils';
+import { replaceLocalhost } from './utils';
+import { fileLog } from '../../server';
 
 export const retrieveTypesZipPath = (
   mfTypesPath: string,
@@ -68,15 +68,13 @@ export const downloadTypesArchive = (hostOptions: Required<HostOptions>) => {
         zip.extractAllTo(destinationPath, true);
         return [destinationFolder, destinationPath];
       } catch (error: any) {
-        if (isDebugMode()) {
-          console.error(
-            ansiColors.red(
-              `Error during types archive download: ${
-                error?.message || 'unknown error'
-              }`,
-            ),
-          );
-        }
+        fileLog(
+          `Error during types archive download: ${
+            error?.message || 'unknown error'
+          }`,
+          'downloadTypesArchive',
+          'error',
+        );
         if (retries >= hostOptions.maxRetries) {
           if (hostOptions.abortOnError !== false) {
             throw error;


### PR DESCRIPTION
## Description

output error in file: when consumer starts and provider not start , it will output too many useless error , so it will be output in file.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
