### PR TITLE
fix: detect whether the project is ts

### DIFF
--- a/.changeset/dry-walls-enjoy.md
+++ b/.changeset/dry-walls-enjoy.md
@@ -1,0 +1,8 @@
+---
+'@module-federation/dts-plugin': patch
+'@module-federation/enhanced': patch
+'website-new': patch
+'@module-federation/sdk': patch
+---
+
+fix: detect whether the project is ts

--- a/apps/website-new/docs/en/configure/dts.mdx
+++ b/apps/website-new/docs/en/configure/dts.mdx
@@ -13,6 +13,7 @@ The `PluginDtsOptions` types are as follows:
 interface PluginDtsOptions {
   generateTypes?: boolean | DtsRemoteOptions;
   consumeTypes?: boolean | DtsHostOptions;
+  tsConfigPath?: string;
 }
 ```
 
@@ -102,7 +103,7 @@ Whether to throw an error when a problem is encountered during type generation
 - Type: `string`
 - Required: No
 - Default value: `path.join(process.cwd(),'./tsconfig.json')`
-
+> priority: dts.generateTypes.tsConfigPath > dts.tsConfigPath
 tsconfig configuration file path
 
 #### typesFolder
@@ -206,3 +207,11 @@ Before loading type files, whether to delete the previously loaded `typesFolder`
 - Default value: `'@mf-types'`
 
 `typesFolder` corresponding to `remotes` directory configuration
+
+### tsConfigPath
+
+- Type: `string`
+- Required: No
+- Default value: `path.join(process.cwd(),'./tsconfig.json')`
+
+tsconfig configuration file path

--- a/apps/website-new/docs/zh/configure/dts.mdx
+++ b/apps/website-new/docs/zh/configure/dts.mdx
@@ -13,6 +13,7 @@
 interface PluginDtsOptions {
   generateTypes?: boolean | DtsRemoteOptions;
   consumeTypes?: boolean | DtsHostOptions;
+  tsConfigPath?: string;
 }
 ```
 
@@ -102,6 +103,7 @@ interface DtsRemoteOptions {
 - 类型：`string`
 - 是否必填：否
 - 默认值：`path.join(process.cwd(),'./tsconfig.json')`
+> 优先级：dts.generateTypes.tsConfigPath > dts.tsConfigPath
 
 tsconfig 配置文件路径
 
@@ -206,3 +208,11 @@ interface DtsHostOptions {
 - 默认值：`'@mf-types'`
 
 对应 `remotes` 目录配置的 `typesFolder`
+
+### tsConfigPath
+
+- 类型：`string`
+- 是否必填：否
+- 默认值：`path.join(process.cwd(),'./tsconfig.json')`
+
+tsconfig 配置文件路径

--- a/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/GenerateTypesPlugin.ts
@@ -51,6 +51,10 @@ export class GenerateTypesPlugin implements WebpackPluginInstance {
       extraOptions: dtsOptions.extraOptions || {},
     };
 
+    if (dtsOptions.tsConfigPath && !finalOptions.remote.tsConfigPath) {
+      finalOptions.remote.tsConfigPath = dtsOptions.tsConfigPath;
+    }
+
     validateOptions(finalOptions.remote);
     const isProd = !isDev();
     const getGenerateTypesFn = () => {

--- a/packages/dts-plugin/src/plugins/TypesPlugin.ts
+++ b/packages/dts-plugin/src/plugins/TypesPlugin.ts
@@ -26,7 +26,12 @@ class TypesPlugin implements WebpackPluginInstance {
     const defaultConsumeTypes = { abortOnError: false, consumeAPITypes: true };
     const normalizedDtsOptions =
       normalizeOptions<moduleFederationPlugin.PluginDtsOptions>(
-        isTSProject(undefined, compiler.context),
+        isTSProject(
+          typeof options.dts === 'object'
+            ? options.dts.tsConfigPath
+            : undefined,
+          compiler.context,
+        ),
         {
           generateTypes: defaultGenerateTypes,
           consumeTypes: defaultConsumeTypes,

--- a/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
+++ b/packages/enhanced/src/schemas/container/ModuleFederationPlugin.ts
@@ -645,6 +645,10 @@ export default {
           type: 'object',
           additionalProperties: true,
         },
+        tsConfigPath: {
+          description: 'The tsconfig path of the project.',
+          type: 'string',
+        },
         implementation: {
           description: 'The implementation of the DTS Manager.',
           type: 'string',

--- a/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
+++ b/packages/sdk/src/types/plugins/ModuleFederationPlugin.ts
@@ -154,6 +154,7 @@ export interface DtsRemoteOptions {
 export interface PluginDtsOptions {
   generateTypes?: boolean | DtsRemoteOptions;
   consumeTypes?: boolean | DtsHostOptions;
+  tsConfigPath?: string;
   extraOptions?: Record<string, any>;
   implementation?: string;
 }


### PR DESCRIPTION
## Description

detect whether the project is ts, if no ,disable dts plugin automatic . 

It also add `dts.tsconfigPath` field

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
