### PR TITLE
feat: align with shared import:false

### DIFF
--- a/.changeset/angry-ways-return.md
+++ b/.changeset/angry-ways-return.md
@@ -1,5 +1,6 @@
 ---
 '@module-federation/runtime': patch
+'@module-federation/enhanced': patch
 ---
 
-feat: align with shared import:false
+feat: support config shared import:false in runtime

--- a/.changeset/angry-ways-return.md
+++ b/.changeset/angry-ways-return.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+feat: align with shared import:false

--- a/packages/runtime/__tests__/share.ts
+++ b/packages/runtime/__tests__/share.ts
@@ -122,3 +122,35 @@ export const arrayShared = {
 export const arraySharedInfos = {
   'react-dom': arrayShared.shared['react-dom'],
 };
+
+export const shareInfoWithoutLibAndGetConsumer = {
+  name: '@federation/shared-config-consumer',
+  remotes: [],
+  shared: {
+    'react-dom': {
+      scope: ['default'],
+      shareConfig: {
+        singleton: true,
+        requiredVersion: '^16.0.0',
+        eager: false,
+      },
+    },
+  },
+};
+
+export const shareInfoWithoutLibAndGetProvider = {
+  name: '@federation/shared-config-provider',
+  remotes: [],
+  shared: {
+    'react-dom': {
+      version: '16.0.0',
+      scope: ['default'],
+      get: () =>
+        Promise.resolve(() => ({
+          default: 'react-dom',
+          version: '16.0.0',
+          from: '@federation/shared-config-provider',
+        })),
+    },
+  },
+};

--- a/packages/runtime/__tests__/shares.spec.ts
+++ b/packages/runtime/__tests__/shares.spec.ts
@@ -7,6 +7,8 @@ import {
   localMergeShareInfos,
   arrayShared,
   arraySharedInfos,
+  shareInfoWithoutLibAndGetConsumer,
+  shareInfoWithoutLibAndGetProvider,
 } from './share';
 // import { assert } from '../src/utils/logger';
 import { FederationHost } from '../src/core';
@@ -33,6 +35,29 @@ describe('shared', () => {
   it('init array shared', () => {
     const FederationInstance = init(arrayShared);
     expect(FederationInstance.options.shared).toMatchObject(arraySharedInfos);
+  });
+
+  it('init shared without lib and get', async () => {
+    const provider = init(shareInfoWithoutLibAndGetProvider);
+
+    await provider.loadShare<{
+      version: string;
+      from: string;
+    }>('react-dom');
+
+    const consumer = init(shareInfoWithoutLibAndGetConsumer);
+    consumer.initShareScopeMap('default', provider.shareScopeMap['default']);
+
+    debugger;
+    const reactDomInstance = await consumer.loadShare<{
+      version: string;
+      from: string;
+    }>('react-dom');
+    assert(reactDomInstance);
+    const reactDomInstanceRes = reactDomInstance();
+    assert(reactDomInstanceRes, "reactInstance can't be undefined");
+    expect(reactDomInstanceRes.from).toBe('@federation/shared-config-provider');
+    expect(reactDomInstanceRes.version).toBe('16.0.0');
   });
 
   it('loadShare singleton', async () => {

--- a/packages/runtime/src/type/config.ts
+++ b/packages/runtime/src/type/config.ts
@@ -53,7 +53,7 @@ export interface SharedConfig {
 }
 
 type SharedBaseArgs = {
-  version: string;
+  version?: string;
   shareConfig?: SharedConfig;
   scope?: string | Array<string>;
   deps?: Array<string>;
@@ -64,7 +64,8 @@ export type SharedGetter = (() => () => Module) | (() => Promise<() => Module>);
 
 export type ShareArgs =
   | (SharedBaseArgs & { get: SharedGetter })
-  | (SharedBaseArgs & { lib: () => Module });
+  | (SharedBaseArgs & { lib: () => Module })
+  | SharedBaseArgs;
 
 export type Shared = {
   version: string;


### PR DESCRIPTION
## Description

in build config , it supports `import:false` , and the runtime need support the config as well. 

### example

**build config** 
```js
new ModuleFederationPlugin({
  shared: {
     'react': { 
         // just use host react
         import: false,
         requiredVersion: '^16.0.0'
      }
  }
})
```

and it equals the below runtime config
```js
import { init } from '@module-federation/runtime';

init({
  shared: {
     react: {
        scope: ['default'],
        // no need to set lib or get
        shareConfig: {
          singleton: true,
          requiredVersion: '^16.0.0',
          eager: false,
        },
     }
  }
})
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the documentation.
