### PR TITLE
feat(native-federation-typescript): speedup

### DIFF
--- a/packages/native-federation-tests/src/index.ts
+++ b/packages/native-federation-tests/src/index.ts
@@ -55,7 +55,7 @@ export const NativeFederationTestsRemote = createUnplugin(
               watchChange: (this as UnpluginOptions).writeBundle,
             };
       },
-      webpack: (compiler) => {
+      webpack(compiler) {
         compiler.options.devServer = mergeDeepRight(
           compiler.options.devServer || {},
           {
@@ -65,7 +65,7 @@ export const NativeFederationTestsRemote = createUnplugin(
           },
         );
       },
-      rspack: (compiler) => {
+      rspack(compiler) {
         compiler.options.devServer = mergeDeepRight(
           compiler.options.devServer || {},
           {

--- a/packages/native-federation-typescript/package.json
+++ b/packages/native-federation-typescript/package.json
@@ -56,7 +56,8 @@
     "ansi-colors": "^4.1.3",
     "axios": "^1.6.7",
     "rambda": "^9.1.0",
-    "unplugin": "^1.9.0"
+    "unplugin": "^1.9.0",
+    "piscina": "^4.4.0"
   },
   "peerDependencies": {
     "typescript": "^4.9.0 || ^5.0.0",

--- a/packages/native-federation-typescript/src/index.test.ts
+++ b/packages/native-federation-typescript/src/index.test.ts
@@ -75,6 +75,13 @@ describe('index', () => {
                 children: [
                   { name: 'archiveHandler.d.ts' },
                   { name: 'typeScriptCompiler.d.ts' },
+                  { 
+                    name: 'writeBundle',
+                    children: [
+                      { name: 'host.d.ts' },
+                      { name: 'remote.d.ts' }
+                    ]
+                  }
                 ],
               },
             ],
@@ -237,6 +244,13 @@ describe('index', () => {
                     children: [
                       { name: 'archiveHandler.d.ts' },
                       { name: 'typeScriptCompiler.d.ts' },
+                      { 
+                        name: 'writeBundle',
+                        children: [
+                          { name: 'host.d.ts' },
+                          { name: 'remote.d.ts' }
+                        ]
+                      }
                     ],
                   },
                 ],

--- a/packages/native-federation-typescript/src/index.test.ts
+++ b/packages/native-federation-typescript/src/index.test.ts
@@ -77,11 +77,8 @@ describe('index', () => {
                   { name: 'typeScriptCompiler.d.ts' },
                   {
                     name: 'writeBundle',
-                    children: [
-                      { name: 'host.d.ts' },
-                      { name: 'remote.d.ts' }
-                    ]
-                  }
+                    children: [{ name: 'host.d.ts' }, { name: 'remote.d.ts' }],
+                  },
                 ],
               },
             ],
@@ -248,9 +245,9 @@ describe('index', () => {
                         name: 'writeBundle',
                         children: [
                           { name: 'host.d.ts' },
-                          { name: 'remote.d.ts' }
-                        ]
-                      }
+                          { name: 'remote.d.ts' },
+                        ],
+                      },
                     ],
                   },
                 ],

--- a/packages/native-federation-typescript/src/index.test.ts
+++ b/packages/native-federation-typescript/src/index.test.ts
@@ -75,7 +75,7 @@ describe('index', () => {
                 children: [
                   { name: 'archiveHandler.d.ts' },
                   { name: 'typeScriptCompiler.d.ts' },
-                  { 
+                  {
                     name: 'writeBundle',
                     children: [
                       { name: 'host.d.ts' },
@@ -244,7 +244,7 @@ describe('index', () => {
                     children: [
                       { name: 'archiveHandler.d.ts' },
                       { name: 'typeScriptCompiler.d.ts' },
-                      { 
+                      {
                         name: 'writeBundle',
                         children: [
                           { name: 'host.d.ts' },

--- a/packages/native-federation-typescript/src/index.ts
+++ b/packages/native-federation-typescript/src/index.ts
@@ -16,12 +16,12 @@ import hostWriteBundle from './lib/writeBundle/host';
 export const NativeFederationTypeScriptRemote = createUnplugin(
   (options: RemoteOptions) => {
     const remoteConfig = retrieveRemoteConfig(options);
-    const { remoteOptions, tsConfig } = remoteConfig
+    const { remoteOptions, tsConfig } = remoteConfig;
     return {
       name: 'native-federation-typescript/remote',
       async writeBundle() {
         try {
-          await remoteWriteBundle(remoteConfig)
+          await remoteWriteBundle(remoteConfig);
 
           console.log(ansiColors.green('Federated types created correctly'));
         } catch (error) {
@@ -34,9 +34,9 @@ export const NativeFederationTypeScriptRemote = createUnplugin(
         return process.env.NODE_ENV === 'production'
           ? undefined
           : {
-            buildStart: (this as UnpluginOptions).writeBundle,
-            watchChange: (this as UnpluginOptions).writeBundle,
-          };
+              buildStart: (this as UnpluginOptions).writeBundle,
+              watchChange: (this as UnpluginOptions).writeBundle,
+            };
       },
       webpack(compiler) {
         compiler.options.devServer = mergeDeepRight(
@@ -80,9 +80,9 @@ export const NativeFederationTypeScriptHost = createUnplugin(
         return process.env.NODE_ENV === 'production'
           ? undefined
           : {
-            buildStart: (this as UnpluginOptions).writeBundle,
-            watchChange: (this as UnpluginOptions).writeBundle,
-          };
+              buildStart: (this as UnpluginOptions).writeBundle,
+              watchChange: (this as UnpluginOptions).writeBundle,
+            };
       },
     };
   },

--- a/packages/native-federation-typescript/src/index.ts
+++ b/packages/native-federation-typescript/src/index.ts
@@ -1,5 +1,4 @@
 import ansiColors from 'ansi-colors';
-import { rm } from 'fs/promises';
 import { resolve } from 'path';
 import { mergeDeepRight } from 'rambda';
 import { UnpluginOptions, createUnplugin } from 'unplugin';
@@ -8,31 +7,22 @@ import { retrieveHostConfig } from './configurations/hostPlugin';
 import { retrieveRemoteConfig } from './configurations/remotePlugin';
 import { HostOptions } from './interfaces/HostOptions';
 import { RemoteOptions } from './interfaces/RemoteOptions';
-import { createTypesArchive, downloadTypesArchive } from './lib/archiveHandler';
-import {
-  compileTs,
-  retrieveMfTypesPath,
-  retrieveOriginalOutDir,
-} from './lib/typeScriptCompiler';
+import { retrieveOriginalOutDir } from './lib/typeScriptCompiler';
+// @ts-expect-error function exported through module.exports
+import remoteWriteBundle from './lib/writeBundle/remote';
+// @ts-expect-error function exported through module.exports
+import hostWriteBundle from './lib/writeBundle/host';
 
 export const NativeFederationTypeScriptRemote = createUnplugin(
   (options: RemoteOptions) => {
-    const { remoteOptions, tsConfig, mapComponentsToExpose } =
-      retrieveRemoteConfig(options);
+    const remoteConfig = retrieveRemoteConfig(options);
+    const { remoteOptions, tsConfig } = remoteConfig
     return {
       name: 'native-federation-typescript/remote',
       async writeBundle() {
         try {
-          compileTs(mapComponentsToExpose, tsConfig, remoteOptions);
+          await remoteWriteBundle(remoteConfig)
 
-          await createTypesArchive(tsConfig, remoteOptions);
-
-          if (remoteOptions.deleteTypesFolder) {
-            await rm(retrieveMfTypesPath(tsConfig, remoteOptions), {
-              recursive: true,
-              force: true,
-            });
-          }
           console.log(ansiColors.green('Federated types created correctly'));
         } catch (error) {
           console.error(
@@ -44,9 +34,9 @@ export const NativeFederationTypeScriptRemote = createUnplugin(
         return process.env.NODE_ENV === 'production'
           ? undefined
           : {
-              buildStart: (this as UnpluginOptions).writeBundle,
-              watchChange: (this as UnpluginOptions).writeBundle,
-            };
+            buildStart: (this as UnpluginOptions).writeBundle,
+            watchChange: (this as UnpluginOptions).writeBundle,
+          };
       },
       webpack(compiler) {
         compiler.options.devServer = mergeDeepRight(
@@ -78,35 +68,21 @@ export const NativeFederationTypeScriptRemote = createUnplugin(
 
 export const NativeFederationTypeScriptHost = createUnplugin(
   (options: HostOptions) => {
-    const { hostOptions, mapRemotesToDownload } = retrieveHostConfig(options);
+    const hostConfig = retrieveHostConfig(options);
     return {
       name: 'native-federation-typescript/host',
       async writeBundle() {
-        if (hostOptions.deleteTypesFolder) {
-          await rm(hostOptions.typesFolder, {
-            recursive: true,
-            force: true,
-          }).catch((error) =>
-            console.error(
-              ansiColors.red(`Unable to remove types folder, ${error}`),
-            ),
-          );
-        }
+        await hostWriteBundle(hostConfig);
 
-        const typesDownloader = downloadTypesArchive(hostOptions);
-        const downloadPromises =
-          Object.entries(mapRemotesToDownload).map(typesDownloader);
-
-        await Promise.allSettled(downloadPromises);
         console.log(ansiColors.green('Federated types extraction completed'));
       },
       get vite() {
         return process.env.NODE_ENV === 'production'
           ? undefined
           : {
-              buildStart: (this as UnpluginOptions).writeBundle,
-              watchChange: (this as UnpluginOptions).writeBundle,
-            };
+            buildStart: (this as UnpluginOptions).writeBundle,
+            watchChange: (this as UnpluginOptions).writeBundle,
+          };
       },
     };
   },

--- a/packages/native-federation-typescript/src/index.ts
+++ b/packages/native-federation-typescript/src/index.ts
@@ -48,7 +48,7 @@ export const NativeFederationTypeScriptRemote = createUnplugin(
               watchChange: (this as UnpluginOptions).writeBundle,
             };
       },
-      webpack: (compiler) => {
+      webpack(compiler) {
         compiler.options.devServer = mergeDeepRight(
           compiler.options.devServer || {},
           {
@@ -60,7 +60,7 @@ export const NativeFederationTypeScriptRemote = createUnplugin(
           },
         );
       },
-      rspack: (compiler) => {
+      rspack(compiler) {
         compiler.options.devServer = mergeDeepRight(
           compiler.options.devServer || {},
           {

--- a/packages/native-federation-typescript/src/lib/writeBundle/host.ts
+++ b/packages/native-federation-typescript/src/lib/writeBundle/host.ts
@@ -1,0 +1,37 @@
+import Piscina from 'piscina'
+import { isMainThread } from 'worker_threads';
+import { rm } from 'fs/promises';
+import ansiColors from 'ansi-colors';
+
+import { HostOptions } from '../../interfaces/HostOptions';
+import { downloadTypesArchive } from '../archiveHandler';
+
+interface HostWriteBundle {
+  hostOptions: Required<HostOptions>
+  mapRemotesToDownload: Record<string, string>
+}
+
+if (isMainThread) {
+  const piscina = new Piscina({ filename: __filename });
+
+  module.exports = piscina.run.bind(piscina)
+} else {
+  module.exports = async ({ hostOptions, mapRemotesToDownload }: HostWriteBundle) => {
+    if (hostOptions.deleteTypesFolder) {
+      await rm(hostOptions.typesFolder, {
+        recursive: true,
+        force: true,
+      }).catch((error) =>
+        console.error(
+          ansiColors.red(`Unable to remove types folder, ${error}`),
+        ),
+      );
+    }
+
+    const typesDownloader = downloadTypesArchive(hostOptions);
+    const downloadPromises =
+      Object.entries(mapRemotesToDownload).map(typesDownloader);
+
+    await Promise.allSettled(downloadPromises);
+  }
+}

--- a/packages/native-federation-typescript/src/lib/writeBundle/host.ts
+++ b/packages/native-federation-typescript/src/lib/writeBundle/host.ts
@@ -1,4 +1,4 @@
-import Piscina from 'piscina'
+import Piscina from 'piscina';
 import { isMainThread } from 'worker_threads';
 import { rm } from 'fs/promises';
 import ansiColors from 'ansi-colors';
@@ -7,16 +7,19 @@ import { HostOptions } from '../../interfaces/HostOptions';
 import { downloadTypesArchive } from '../archiveHandler';
 
 interface HostWriteBundle {
-  hostOptions: Required<HostOptions>
-  mapRemotesToDownload: Record<string, string>
+  hostOptions: Required<HostOptions>;
+  mapRemotesToDownload: Record<string, string>;
 }
 
 if (isMainThread) {
   const piscina = new Piscina({ filename: __filename });
 
-  module.exports = piscina.run.bind(piscina)
+  module.exports = piscina.run.bind(piscina);
 } else {
-  module.exports = async ({ hostOptions, mapRemotesToDownload }: HostWriteBundle) => {
+  module.exports = async ({
+    hostOptions,
+    mapRemotesToDownload,
+  }: HostWriteBundle) => {
     if (hostOptions.deleteTypesFolder) {
       await rm(hostOptions.typesFolder, {
         recursive: true,
@@ -33,5 +36,5 @@ if (isMainThread) {
       Object.entries(mapRemotesToDownload).map(typesDownloader);
 
     await Promise.allSettled(downloadPromises);
-  }
+  };
 }

--- a/packages/native-federation-typescript/src/lib/writeBundle/remote.ts
+++ b/packages/native-federation-typescript/src/lib/writeBundle/remote.ts
@@ -1,0 +1,33 @@
+import Piscina from 'piscina'
+import ts from "typescript"
+import { rm } from "fs/promises"
+import { isMainThread } from 'worker_threads';
+
+import { RemoteOptions } from "../../interfaces/RemoteOptions"
+import { compileTs, retrieveMfTypesPath } from "../typeScriptCompiler"
+import { createTypesArchive } from "../archiveHandler"
+
+interface RemoteWriteBundle {
+    remoteOptions: Required<RemoteOptions>
+    tsConfig: ts.CompilerOptions
+    mapComponentsToExpose: Record<string, string>
+}
+
+if (isMainThread) {
+    const piscina = new Piscina({ filename: __filename });
+
+    module.exports = piscina.run.bind(piscina)
+} else {
+    module.exports = async ({ remoteOptions, tsConfig, mapComponentsToExpose }: RemoteWriteBundle) => {
+        compileTs(mapComponentsToExpose, tsConfig, remoteOptions);
+
+        await createTypesArchive(tsConfig, remoteOptions);
+
+        if (remoteOptions.deleteTypesFolder) {
+            await rm(retrieveMfTypesPath(tsConfig, remoteOptions), {
+                recursive: true,
+                force: true,
+            });
+        }
+    }
+}

--- a/packages/native-federation-typescript/src/lib/writeBundle/remote.ts
+++ b/packages/native-federation-typescript/src/lib/writeBundle/remote.ts
@@ -1,33 +1,37 @@
-import Piscina from 'piscina'
-import ts from "typescript"
-import { rm } from "fs/promises"
+import Piscina from 'piscina';
+import ts from 'typescript';
+import { rm } from 'fs/promises';
 import { isMainThread } from 'worker_threads';
 
-import { RemoteOptions } from "../../interfaces/RemoteOptions"
-import { compileTs, retrieveMfTypesPath } from "../typeScriptCompiler"
-import { createTypesArchive } from "../archiveHandler"
+import { RemoteOptions } from '../../interfaces/RemoteOptions';
+import { compileTs, retrieveMfTypesPath } from '../typeScriptCompiler';
+import { createTypesArchive } from '../archiveHandler';
 
 interface RemoteWriteBundle {
-    remoteOptions: Required<RemoteOptions>
-    tsConfig: ts.CompilerOptions
-    mapComponentsToExpose: Record<string, string>
+  remoteOptions: Required<RemoteOptions>;
+  tsConfig: ts.CompilerOptions;
+  mapComponentsToExpose: Record<string, string>;
 }
 
 if (isMainThread) {
-    const piscina = new Piscina({ filename: __filename });
+  const piscina = new Piscina({ filename: __filename });
 
-    module.exports = piscina.run.bind(piscina)
+  module.exports = piscina.run.bind(piscina);
 } else {
-    module.exports = async ({ remoteOptions, tsConfig, mapComponentsToExpose }: RemoteWriteBundle) => {
-        compileTs(mapComponentsToExpose, tsConfig, remoteOptions);
+  module.exports = async ({
+    remoteOptions,
+    tsConfig,
+    mapComponentsToExpose,
+  }: RemoteWriteBundle) => {
+    compileTs(mapComponentsToExpose, tsConfig, remoteOptions);
 
-        await createTypesArchive(tsConfig, remoteOptions);
+    await createTypesArchive(tsConfig, remoteOptions);
 
-        if (remoteOptions.deleteTypesFolder) {
-            await rm(retrieveMfTypesPath(tsConfig, remoteOptions), {
-                recursive: true,
-                force: true,
-            });
-        }
+    if (remoteOptions.deleteTypesFolder) {
+      await rm(retrieveMfTypesPath(tsConfig, remoteOptions), {
+        recursive: true,
+        force: true,
+      });
     }
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1417,6 +1417,9 @@ importers:
       axios:
         specifier: ^1.6.7
         version: 1.6.7
+      piscina:
+        specifier: ^4.4.0
+        version: 4.4.0
       rambda:
         specifier: ^9.1.0
         version: 9.2.0
@@ -24488,8 +24491,6 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
-      webpack-sources:
-        optional: true
     dependencies:
       webpack: 5.91.0(@swc/core@1.3.102)(esbuild@0.18.20)
       webpack-sources: 3.2.3
@@ -26288,6 +26289,16 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /nice-napi@1.0.2:
+    resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
+    os: ['!win32']
+    requiresBuild: true
+    dependencies:
+      node-addon-api: 3.2.1
+      node-gyp-build: 4.8.0
+    dev: false
+    optional: true
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -26301,7 +26312,6 @@ packages:
 
   /node-addon-api@3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
-    dev: true
 
   /node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -26372,7 +26382,6 @@ packages:
   /node-gyp-build@4.8.0:
     resolution: {integrity: sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==}
     hasBin: true
-    dev: true
 
   /node-html-markdown@1.3.0:
     resolution: {integrity: sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==}
@@ -27713,6 +27722,12 @@ packages:
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
+
+  /piscina@4.4.0:
+    resolution: {integrity: sha512-+AQduEJefrOApE4bV7KRmp3N2JnnyErlVqq4P/jmko4FPz9Z877BCccl/iB3FdrWSUkvbGV9Kan/KllJgat3Vg==}
+    optionalDependencies:
+      nice-napi: 1.0.2
+    dev: false
 
   /pkg-conf@2.1.0:
     resolution: {integrity: sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==}


### PR DESCRIPTION
According to the previous PRs made by @2heal1, I think that there's no need to build custom classes to manage rpc in order to speed up things.

Instantiation an additional process each time that types are compiled/downloaded can be costly: using piscina, which wraps worker threads, can help us achieving the same result with a more concise code.

Of course, if the methodology is approved, I'm going to implement it for native-federation-tests as well