### PR TITLE
fix(runtime): preserve generic in loadRemote/loadShare/loadShareSync (#2325)

### DIFF
--- a/.changeset/tasty-parents-guess.md
+++ b/.changeset/tasty-parents-guess.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/runtime': patch
+---
+
+fix: preserve generic in loadRemote/loadShare/loadShareSync

--- a/packages/runtime/__tests__/global.spec.ts
+++ b/packages/runtime/__tests__/global.spec.ts
@@ -1,5 +1,5 @@
-import { assert, describe, test, it, vi } from 'vitest';
-import { init } from '../src/index';
+import { assert, describe, test, it, vi, expectTypeOf } from 'vitest';
+import { init, loadRemote, loadShare, loadShareSync } from '../src/index';
 import { getInfoWithoutType } from '../src/global';
 
 describe('global', () => {
@@ -42,6 +42,34 @@ describe('global', () => {
     expect(res3).toMatchObject({
       key: 'npm:@federation/app4',
       value: 4,
+    });
+  });
+
+  describe('global types (generic)', () => {
+    it('loadRemote', async () => {
+      const typedLoadRemote: typeof loadRemote<string> = loadRemote;
+      expectTypeOf(typedLoadRemote).returns.toMatchTypeOf<
+        Promise<string | null>
+      >();
+      expectTypeOf(typedLoadRemote).returns.not.toMatchTypeOf<Promise<null>>();
+    });
+
+    it('loadShare', async () => {
+      const typedLoadShare: typeof loadShare<string> = loadShare;
+      expectTypeOf(typedLoadShare).returns.toMatchTypeOf<
+        Promise<false | (() => string | undefined)>
+      >();
+      expectTypeOf(typedLoadShare).returns.not.toMatchTypeOf<
+        Promise<false | (() => undefined)>
+      >();
+    });
+
+    it('loadShareSync', async () => {
+      const typedLoadShareSync: typeof loadShareSync<string> = loadShareSync;
+      expectTypeOf(typedLoadShareSync).returns.toMatchTypeOf<
+        () => string | never
+      >();
+      expectTypeOf(typedLoadShareSync).returns.not.toMatchTypeOf<() => never>();
     });
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -37,28 +37,34 @@ export function init(options: UserOptions): FederationHost {
   }
 }
 
-export function loadRemote(
+export function loadRemote<T>(
   ...args: Parameters<FederationHost['loadRemote']>
-): ReturnType<FederationHost['loadRemote']> {
+): Promise<T | null> {
   assert(FederationInstance, 'Please call init first');
+  const loadRemote: typeof FederationInstance.loadRemote<T> =
+    FederationInstance.loadRemote;
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.loadRemote.apply(FederationInstance, args);
+  return loadRemote.apply(FederationInstance, args);
 }
 
-export function loadShare(
+export function loadShare<T>(
   ...args: Parameters<FederationHost['loadShare']>
-): ReturnType<FederationHost['loadShare']> {
+): Promise<false | (() => T | undefined)> {
   assert(FederationInstance, 'Please call init first');
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.loadShare.apply(FederationInstance, args);
+  const loadShare: typeof FederationInstance.loadShare<T> =
+    FederationInstance.loadShare;
+  return loadShare.apply(FederationInstance, args);
 }
 
-export function loadShareSync(
+export function loadShareSync<T>(
   ...args: Parameters<FederationHost['loadShareSync']>
-): ReturnType<FederationHost['loadShareSync']> {
+): () => T | never {
   assert(FederationInstance, 'Please call init first');
+  const loadShareSync: typeof FederationInstance.loadShareSync<T> =
+    FederationInstance.loadShareSync;
   // eslint-disable-next-line prefer-spread
-  return FederationInstance.loadShareSync.apply(FederationInstance, args);
+  return loadShareSync.apply(FederationInstance, args);
 }
 
 export function preloadRemote(


### PR DESCRIPTION
## Description

(runtime) global loadRemote doesn't support generic (ts fails)

So I've added support for:
- loadShare
- loadShareSync
- loadRemote

## Related Issue

#2325

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
