### PR TITLE
feat(enhanced): chunk matcher to federation runtime

### DIFF
--- a/.changeset/green-news-leave.md
+++ b/.changeset/green-news-leave.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+add chunk matcher logic to federation runtime module

--- a/packages/enhanced/src/lib/container/runtime/getFederationGlobal.ts
+++ b/packages/enhanced/src/lib/container/runtime/getFederationGlobal.ts
@@ -10,6 +10,8 @@ const { Template } = require(
 function getFederationGlobal(
   template: typeof Template,
   runtimeGlobals: typeof RuntimeGlobals,
+  matcher: string | boolean,
+  rootOutputDir: string | undefined,
   initOptionsWithoutShared: NormalizedRuntimeInitOptionsWithOutShared,
 ): string {
   const federationGlobal = getFederationGlobalScope(runtimeGlobals);
@@ -21,6 +23,8 @@ function getFederationGlobal(
       `${federationGlobal} = {`,
       template.indent([
         `initOptions: ${initOptionsStrWithoutShared},`,
+        `chunkMatcher: function(chunkId) {return ${matcher}},`,
+        `rootOutputDir: ${JSON.stringify(rootOutputDir || '')},`,
         `initialConsumes: undefined,`,
         'bundlerRuntimeOptions: {}',
       ]),


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Add ensureChunk JS matcher function to accessable location at runtime
<!--- Describe your changes in detail -->
This allows us to add custom runtime plugins like node federation which replace or add to require.f but to do so we need to know what is a real JS chunk to match on. 

exampe:
```js
   // Dynamic filesystem chunk loading for javascript
        if (__webpack_require__.f) {
          const handle = function (chunkId, promises) {
            var installedChunkData = installedChunks[chunkId];
            if (installedChunkData !== 0) {
              // 0 means "already installed".
              if (installedChunkData) {
                promises.push(installedChunkData[2]);
              } else {
              // here is matcher
                const matcher = __webpack_require__.federation.chunkMatcher
                  ? __webpack_require__.federation.chunkMatcher(chunkId)
                  : true;
                if (matcher) {
 ```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the documentation.
