### PR TITLE
feat(enhanced): improve async boundary for sibling chunk dep

### DIFF
--- a/.changeset/pink-bulldogs-laugh.md
+++ b/.changeset/pink-bulldogs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@module-federation/enhanced': patch
+---
+
+Improve Async Boundary Plugin on entry that use dependOn and improve chunk dep search

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -68,4 +68,4 @@ jobs:
         run: pnpm app:next:build
 
       - name: E2E Node Federation
-        run: npx nx run-many --target=serve --projects=node-local-remote,node-remote --parallel=3 & echo "done" && sleep 10 && npx nx run-many --target=serve --projects=node-host & echo "done" && npx nx run node-host-e2e:test:e2e
+        run: npx nx run-many --target=serve --projects=node-local-remote,node-remote --parallel=3 & echo "done" && sleep 10 && npx nx run-many --target=serve --projects=node-host & npx wait-on tcp:3333 && npx nx run node-host-e2e:test:e2e


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
Improve async boundary for split chunk rules and cases where dependOn is used on entrypoints
<!--- Describe your changes in detail -->
Should search deep in chunks for remote modules and should collect all initial chunks needed for boundary 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
